### PR TITLE
Make map and player name filter case-insensitive

### DIFF
--- a/Server/app.js
+++ b/Server/app.js
@@ -113,11 +113,12 @@ app.get("/get-files", (req, res, next) => {
     console.log(req.query);
     const raceData = db.collection('race_data');
     var query = {};
+    // case-insensitive filter for map and player name
     if (req.query.mapName.length > 0) {
-        query["mapName"] = {$regex : ".*" + req.query.mapName + ".*"};
+        query["mapName"] = {$regex : ".*" + req.query.mapName + ".*", $options : 'i'};
     }
     if (req.query.playerName.length > 0) {
-        query["playerName"] = {$regex : ".*" + req.query.playerName + ".*"};
+        query["playerName"] = {$regex : ".*" + req.query.playerName + ".*", $options : "i"};
     }
     if (req.query.raceFinished != -1) {
         query["raceFinished"] = parseInt(req.query.raceFinished);


### PR DESCRIPTION
Just a small change to how the server matches map and player names in the DB - this is not super-performant at really high loads tbh, but it should be fine for now.

If it turns out that this is creating problems, we might have to think about adding an extra field in each document for the lowercase version of the names 😕 