### PR TITLE
Adaptive grid

### DIFF
--- a/app/components/viewer/Grid.tsx
+++ b/app/components/viewer/Grid.tsx
@@ -1,16 +1,61 @@
 import React from "react";
 import * as THREE from "three";
+import { Vector3 } from "three";
+import { ReplayData } from "../../lib/api/fileRequests";
+import { BLOCK_SIZE } from "../../lib/constants/block";
 
 const GRID_COLOR = new THREE.Color(0.01, 0.01, 0.01);
-const GRID_SIZE = 48 * 32;
-const GRID_DIVISIONS = 32;
-export const GRID_POS = new THREE.Vector3(GRID_SIZE / 2, 0, GRID_SIZE / 2);
+const DEFAULT_GRID_SIZE = 48 * 32;
+const DEFAULT_GRID_DIVISIONS = DEFAULT_GRID_SIZE / 32;
+export const DEFAULT_GRID_POS = new THREE.Vector3(DEFAULT_GRID_SIZE / 2, 0, DEFAULT_GRID_SIZE / 2);
 
-export const Grid = (): JSX.Element => {
+interface GridProps {
+    replaysData: ReplayData[];
+    blockPadding: number;
+}
+export const Grid = ({ replaysData, blockPadding }: GridProps): JSX.Element => {
+    let minPos = new THREE.Vector3(Infinity, Infinity, Infinity);
+    let maxPos = new THREE.Vector3(-Infinity, -Infinity, -Infinity);
+
+    // Set default grid parameters
+    let gridSize = DEFAULT_GRID_SIZE;
+    let gridDivisions = DEFAULT_GRID_DIVISIONS;
+    let gridPos = DEFAULT_GRID_POS;
+
+    if (replaysData.length > 0) {
+        for (let i = 0; i < replaysData.length; i += 1) {
+            const replay = replaysData[i];
+            minPos = minPos.min(replay.minPos);
+            maxPos = maxPos.max(replay.maxPos);
+        }
+
+        // Round min and max pos to block positions
+        minPos = minPos.divide(BLOCK_SIZE).floor().multiply(BLOCK_SIZE);
+        maxPos = maxPos.divide(BLOCK_SIZE).ceil().multiply(BLOCK_SIZE);
+
+        // Set grid pos to middle of min and max, then round to a block pos
+        gridPos = new Vector3((minPos.x + maxPos.x) / 2, minPos.y - 8, (minPos.z + maxPos.z) / 2);
+        gridPos = gridPos
+            .divide(BLOCK_SIZE)
+            .round()
+            .multiply(BLOCK_SIZE)
+            .add(new Vector3(16, 0, 16));
+
+        // Set grid size to the longest axis, round to block size, and add padding
+        gridSize = Math.max(maxPos.x - minPos.x, maxPos.z - minPos.z);
+        gridSize = Math.ceil(gridSize / 32) * 32;
+        gridSize += blockPadding * 2 * 32;
+
+        // Amount of grid divisions is equal to the size divided by the size of a block
+        gridDivisions = gridSize / 32;
+    }
+
     return (
-        <gridHelper
-            args={[GRID_SIZE, GRID_DIVISIONS, GRID_COLOR, GRID_COLOR]}
-            position={GRID_POS}
-        />
+        <>
+            <gridHelper
+                args={[gridSize, gridDivisions, GRID_COLOR, GRID_COLOR]}
+                position={gridPos}
+            />
+        </>
     );
 };

--- a/app/components/viewer/Viewer3D.tsx
+++ b/app/components/viewer/Viewer3D.tsx
@@ -28,7 +28,7 @@ export const Viewer3D = ({ replaysData }: Props): JSX.Element => {
             >
                 <color attach="background" args={[BACKGROUND_COLOR]} />
                 <CameraController />
-                <Grid />
+                <Grid replaysData={replaysData} blockPadding={2} />
                 <ReplayLines replaysData={replaysData} lineType={lineType} />
             </Canvas>
         </div>

--- a/app/lib/api/fileRequests.ts
+++ b/app/lib/api/fileRequests.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { readDataView, ReplayDataPoint } from "../replays/replayData";
+import { readDataView, ReplayDataPoint, DataViewResult } from "../replays/replayData";
 
 interface FilterParams {
     mapName: any;
@@ -42,10 +42,6 @@ const DEFAULT_FILTERS = {
     orderBy: "None",
 };
 
-export interface ReplayData extends FileResponse {
-    samples: ReplayDataPoint[];
-}
-
 export const getFiles = async (filters: FilterParams = DEFAULT_FILTERS): Promise<FilesResult> => {
     // TODO: Add correct URL for prod (use a .env file)
     const res = await axios.get(process.env.NEXT_PUBLIC_API_URL + "/get-files", {
@@ -56,6 +52,7 @@ export const getFiles = async (filters: FilterParams = DEFAULT_FILTERS): Promise
     return res.data;
 };
 
+export interface ReplayData extends FileResponse, DataViewResult {}
 export const fetchReplayData = async (file: FileResponse): Promise<ReplayData> => {
     const res = await axios.get(process.env.NEXT_PUBLIC_API_URL + "/get-race-data", {
         params: { filePath: file.file_path },
@@ -63,7 +60,7 @@ export const fetchReplayData = async (file: FileResponse): Promise<ReplayData> =
     });
 
     const dataView = new DataView(res.data);
-    const samples = readDataView(dataView);
+    const { samples, minPos, maxPos } = readDataView(dataView);
 
-    return { ...file, samples };
+    return { ...file, samples, minPos, maxPos };
 };

--- a/app/lib/constants/block.ts
+++ b/app/lib/constants/block.ts
@@ -1,0 +1,3 @@
+import { Vector3 } from "three";
+
+export const BLOCK_SIZE = new Vector3(32, 8, 32);

--- a/app/lib/replays/replayData.ts
+++ b/app/lib/replays/replayData.ts
@@ -56,11 +56,24 @@ export class ReplayDataPoint {
     };
 }
 
-export const readDataView = (dataView: DataView): ReplayDataPoint[] => {
+export interface DataViewResult {
+    samples: ReplayDataPoint[];
+    minPos: THREE.Vector3;
+    maxPos: THREE.Vector3;
+}
+
+export const readDataView = (dataView: DataView): DataViewResult => {
     const samples = [];
+
+    let minPos = new THREE.Vector3(Infinity, Infinity, Infinity);
+    let maxPos = new THREE.Vector3(-Infinity, -Infinity, -Infinity);
+
     for (let i = 0; i < dataView.byteLength; i += 76) {
         const s = new ReplayDataPoint(dataView, i);
         samples.push(s);
+        minPos = minPos.min(s.position);
+        maxPos = maxPos.max(s.position);
     }
-    return samples;
+
+    return { samples, minPos, maxPos };
 };


### PR DESCRIPTION
Adjust grid by the size of the loaded replays:
* When loading in replays, store their min and max positions
* In the grid, get the min and max position of all replays
  * Set center of the grid to the middle of the min and max
  * Round center to be at the center of a block position
  * Set size to the largest distance along either the X or Z axis (threejs's GridHelper only allows for square grids, so we take the largest distance to cover both the X and Z axis)
  * Set grid divisions to the size / 32