### PR TITLE
Various style fixes and map view cleanup

### DIFF
--- a/app/components/maps/SidebarReplays.tsx
+++ b/app/components/maps/SidebarReplays.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Button, Drawer, Table } from "antd";
 import { ColumnsType, TablePaginationConfig } from "antd/lib/table";
 import { FileResponse } from "../../lib/api/apiRequests";
@@ -33,6 +33,12 @@ export const SidebarReplays = ({
     const [visible, setVisible] = useState(false);
     const [visibleReplays, setVisibleReplays] = useState<FileResponse[]>([]);
 
+    useEffect(() => {
+        // initialize visible replays with the first 25
+        const initiallyVisibleReplays = replays.slice(0, 25);
+        setVisibleReplays(() => addReplayInfo(initiallyVisibleReplays));
+    }, [replays]);
+
     const onClose = () => {
         setVisible(false);
     };
@@ -49,13 +55,6 @@ export const SidebarReplays = ({
     };
 
     const columns: ColumnsType<ExtendedFileResponse> = [
-        {
-            title: "Map",
-            dataIndex: "mapName",
-            filters: getUniqueFilters((replay) => replay.mapName),
-            onFilter: (value, record) => record.mapName === value,
-            filterMultiple: false,
-        },
         {
             title: "Player",
             dataIndex: "playerName",
@@ -101,7 +100,7 @@ export const SidebarReplays = ({
             title: "",
             key: "load",
             align: "center",
-            width: 80,
+            width: 120,
             render: (_, replay) => {
                 const selected = selectedReplayDataIds.indexOf(replay._id) != -1;
                 return !selected ? (
@@ -205,7 +204,7 @@ export const SidebarReplays = ({
                         columns={columns}
                         size="small"
                         pagination={{ defaultPageSize: 25 }}
-                        scroll={{ scrollToFirstRowOnChange: true, y: 675, x: "max-content" }}
+                        scroll={{ scrollToFirstRowOnChange: true }}
                     />
                 </div>
             </Drawer>

--- a/app/components/maps/SidebarReplays.tsx
+++ b/app/components/maps/SidebarReplays.tsx
@@ -30,12 +30,14 @@ export const SidebarReplays = ({
     onRemoveAllReplays,
     selectedReplayDataIds,
 }: Props): JSX.Element => {
+    const defaultPageSize = 25;
+
     const [visible, setVisible] = useState(false);
     const [visibleReplays, setVisibleReplays] = useState<FileResponse[]>([]);
 
     useEffect(() => {
-        // initialize visible replays with the first 25
-        const initiallyVisibleReplays = replays.slice(0, 25);
+        // initialize visible replays with the first page
+        const initiallyVisibleReplays = replays.slice(0, defaultPageSize);
         setVisibleReplays(() => addReplayInfo(initiallyVisibleReplays));
     }, [replays]);
 
@@ -203,7 +205,7 @@ export const SidebarReplays = ({
                         dataSource={addReplayInfo(replays)}
                         columns={columns}
                         size="small"
-                        pagination={{ defaultPageSize: 25 }}
+                        pagination={{ defaultPageSize }}
                         scroll={{ scrollToFirstRowOnChange: true }}
                     />
                 </div>

--- a/app/lib/utils/time.ts
+++ b/app/lib/utils/time.ts
@@ -18,19 +18,30 @@ export const timeDifference = (current: number, previous: number): string => {
     const msPerMonth = msPerDay * 30;
     const msPerYear = msPerDay * 365;
 
+    // helper function to omit the "s" when value is 1
+    const addPlural = (time: number) => {
+        return time === 1 ? "" : "s";
+    };
+
     const elapsed = current - previous;
 
     if (elapsed < msPerMinute) {
-        return Math.round(elapsed / 1000) + " seconds ago";
+        const time = Math.round(elapsed / 1000);
+        return `${time} second${addPlural(time)} ago`;
     } else if (elapsed < msPerHour) {
-        return Math.round(elapsed / msPerMinute) + " minutes ago";
+        const time = Math.round(elapsed / msPerMinute);
+        return `${time} minute${addPlural(time)} ago`;
     } else if (elapsed < msPerDay) {
-        return Math.round(elapsed / msPerHour) + " hours ago";
+        const time = Math.round(elapsed / msPerHour);
+        return `${time} hour${addPlural(time)} ago`;
     } else if (elapsed < msPerMonth) {
-        return Math.round(elapsed / msPerDay) + " days ago";
+        const time = Math.round(elapsed / msPerDay);
+        return `${time} day${addPlural(time)} ago`;
     } else if (elapsed < msPerYear) {
-        return Math.round(elapsed / msPerMonth) + " months ago";
+        const time = Math.round(elapsed / msPerMonth);
+        return `${time} month${addPlural(time)} ago`;
     } else {
-        return Math.round(elapsed / msPerYear) + " years ago";
+        const time = Math.round(elapsed / msPerYear);
+        return `${time} year${addPlural(time)} ago`;
     }
 };

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -17,3 +17,17 @@
 .dojo-map-search-table {
     height: 50vh;
 }
+
+/* alignment fixes - TODO: find out why they even happen */
+.ant-table-column-sorters {
+    line-height: 1 !important;
+}
+.ant-input-search-button {
+    line-height: 0.8 !important;
+}
+.ant-page-header-back {
+    line-height: 0.5 !important;
+}
+.ant-drawer-close {
+    line-height: 0.5 !important;
+}


### PR DESCRIPTION
- Initialized `visibleReplays` (which means the "Load all visible" button should now always work)
- Removed map column from replay table (since the table is only visible in the context of a single map)
- Made the button column in the replay table wider so the buttons don't move around
- Removed unnecessary (?) scroll styling that led to an inactive scroll bar at all times - we can always change it again, but I think it's just not necessary
- Fixed time strings for values of `1`
- Manually fixed a bunch of icon misalignments due to broken line-heights