### PR TITLE
Async load all replays

### DIFF
--- a/app/pages/maps/[mapUId].tsx
+++ b/app/pages/maps/[mapUId].tsx
@@ -57,13 +57,14 @@ const Home = (): JSX.Element => {
         replays: FileResponse[],
         selectedReplayDataIds: string[]
     ) => {
-        const fetchedReplays = [];
-        for (let i = 0; i < replays.length; i++) {
-            if (selectedReplayDataIds.indexOf(replays[i]._id) == -1) {
-                const replayData = await fetchReplayData(replays[i]);
-                fetchedReplays.push(replayData);
-            }
-        }
+        const filtered = replays.filter(
+            (replay) => selectedReplayDataIds.indexOf(replay._id) == -1
+        );
+        const fetchedReplays = await Promise.all(
+            filtered.map((replay) => {
+                return fetchReplayData(replay);
+            })
+        );
         setSelectedReplayData([...selectedReplayData, ...fetchedReplays]);
     };
 


### PR DESCRIPTION
Loads all replays using `Promise.all` instead of awaiting each one separatey