### PR TITLE
Switch to dark theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*.code-workspace

--- a/app/components/maps/SidebarReplays.tsx
+++ b/app/components/maps/SidebarReplays.tsx
@@ -206,7 +206,7 @@ export const SidebarReplays = ({
                             <Button
                                 shape="circle"
                                 size="large"
-                                icon={<ReloadOutlined style={{ color: "rgba(0, 0, 0, 0.85)" }} />}
+                                icon={<ReloadOutlined />}
                                 onClick={onRefreshReplays}
                             />
                         </Tooltip>

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -60,7 +60,7 @@ const Home = (): JSX.Element => {
                             <Button
                                 shape="circle"
                                 size="large"
-                                icon={<ReloadOutlined style={{ color: "rgba(0, 0, 0, 0.85)" }} />}
+                                icon={<ReloadOutlined />}
                                 onClick={fetchMaps}
                             />
                         </Tooltip>

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -2,7 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-@import "~antd/dist/antd.css";
+@import "~antd/dist/antd.dark.css";
 
 @import url("https://fonts.googleapis.com/css?family=Inter:100,200,300,400,500,600,700,800,900&display=swap");
 


### PR DESCRIPTION
- Switched to use the default dark theme (to fit the viewer) - no runtime switches possible (yet)
- Removed manual coloring from refresh buttons (to make sure they fit the theme)
- Added VS Code workspace file to .gitignore

The landing page doesn't look amazing cause the background is way too dark - but it works for now, and the whole landing page will change a lot anyway.

We might want to think about letting the user switch between a dark and a light theme at some point - there's some guidance for that in the Ant docs.