### PR TITLE
Open header links in new tab

### DIFF
--- a/app/components/maps/MapHeader.tsx
+++ b/app/components/maps/MapHeader.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { PageHeader, Button } from "antd";
 
@@ -19,26 +20,22 @@ export const MapHeader = ({ mapInfo }: Props): JSX.Element => {
             subTitle={cleanTMFormatting(mapInfo.name || "")}
             extra={
                 <>
-                    <Button
-                        key="tm.io"
-                        type="primary"
-                        onClick={() => {
-                            // TODO: how do we want to route? probably should have a convention
-                            location.href = `https://trackmania.io/#/leaderboard/${mapInfo.mapUid}`;
-                        }}
-                    >
-                        trackmania.io
-                    </Button>
+                    <Link href={`https://trackmania.io/#/leaderboard/${mapInfo.mapUid}`}>
+                        <a target="__blank">
+                            <Button key="tm.io" type="primary">
+                                trackmania.io
+                            </Button>
+                        </a>
+                    </Link>
+
                     {mapInfo.exchangeid ? (
-                        <Button
-                            key="tmx"
-                            type="primary"
-                            onClick={() => {
-                                location.href = `https://trackmania.exchange/maps/${mapInfo.exchangeid}`;
-                            }}
-                        >
-                            TM Exchange
-                        </Button>
+                        <Link href={`https://trackmania.exchange/maps/${mapInfo.exchangeid}`}>
+                            <a target="__blank">
+                                <Button key="tmx" type="primary">
+                                    TM Exchange
+                                </Button>
+                            </a>
+                        </Link>
                     ) : (
                         <></>
                     )}


### PR DESCRIPTION
Quick PR to make the header buttons open in a new tab (using Next links and `a` nodes, which also makes middle-click work properly).