### PR TITLE
Disable TMX button for invalid TMX IDs

### DIFF
--- a/app/components/maps/MapHeader.tsx
+++ b/app/components/maps/MapHeader.tsx
@@ -13,6 +13,14 @@ interface Props {
 export const MapHeader = ({ mapInfo }: Props): JSX.Element => {
     const router = useRouter();
 
+    const hasExchangeId = mapInfo.exchangeid !== undefined && mapInfo.exchangeid !== 0;
+
+    const TmxButton = () => (
+        <Button key="tmx" type="primary" disabled={!hasExchangeId}>
+            TM Exchange
+        </Button>
+    );
+
     return (
         <PageHeader
             onBack={() => router.push("/")}
@@ -28,16 +36,14 @@ export const MapHeader = ({ mapInfo }: Props): JSX.Element => {
                         </a>
                     </Link>
 
-                    {mapInfo.exchangeid ? (
+                    {hasExchangeId ? (
                         <Link href={`https://trackmania.exchange/maps/${mapInfo.exchangeid}`}>
                             <a target="__blank">
-                                <Button key="tmx" type="primary">
-                                    TM Exchange
-                                </Button>
+                                <TmxButton />
                             </a>
                         </Link>
                     ) : (
-                        <></>
+                        <TmxButton />
                     )}
                 </>
             }


### PR DESCRIPTION
The `exchangeid` in mapInfo can be either `undefined` or `0` (this is what tm.io returns for some maps). This PR disables the TMX button for maps where the TMX id is not valid:

![image](https://user-images.githubusercontent.com/22432233/119359076-857d2c00-bca9-11eb-9b65-b7a04c939238.png)
