### PR TITLE
Clean replay list size + Add page title

### DIFF
--- a/app/components/common/HeadTitle.tsx
+++ b/app/components/common/HeadTitle.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import Head from "next/head";
+import { MapInfo } from "../../lib/api/apiRequests";
+import { cleanTMFormatting } from "../../lib/utils/formatting";
+
+interface HeadTitleProps {
+    mapInfo?: MapInfo;
+}
+export const HeadTitle = ({ mapInfo }: HeadTitleProps): JSX.Element => {
+    const mapName = mapInfo && mapInfo.name && cleanTMFormatting(mapInfo.name);
+
+    const pageTitle = `${mapName ? `${mapName} -` : ""} TMDojo`;
+
+    return (
+        <Head>
+            <title>{pageTitle}</title>
+        </Head>
+    );
+};

--- a/app/components/maps/SidebarReplays.tsx
+++ b/app/components/maps/SidebarReplays.tsx
@@ -33,7 +33,7 @@ export const SidebarReplays = ({
     onRefreshReplays,
     selectedReplayDataIds,
 }: Props): JSX.Element => {
-    const defaultPageSize = 25;
+    const defaultPageSize = 14;
 
     const [visible, setVisible] = useState(false);
     const [visibleReplays, setVisibleReplays] = useState<FileResponse[]>([]);
@@ -183,7 +183,7 @@ export const SidebarReplays = ({
                 visible={visible}
                 className={"h-screen"}
             >
-                <div className="flex flex-row justify-between items-center mb-6 mt-2 mx-4">
+                <div className="flex flex-row justify-between items-center mb-4 mx-4">
                     <div className="flex flex-row gap-4">
                         <Button
                             type="primary"
@@ -220,7 +220,10 @@ export const SidebarReplays = ({
                         dataSource={addReplayInfo(replays)}
                         columns={columns}
                         size="small"
-                        pagination={{ defaultPageSize }}
+                        pagination={{
+                            pageSize: defaultPageSize,
+                            position: ["bottomCenter"],
+                        }}
                         scroll={{ scrollToFirstRowOnChange: true }}
                     />
                 </div>

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { HeadTitle } from "../components/common/HeadTitle";
 import { SettingsProvider } from "../lib/contexts/SettingsContext";
 import "../styles/globals.css";
 
@@ -10,6 +11,7 @@ interface Props {
 const MyApp = ({ Component, pageProps }: Props): React.ReactElement => {
     return (
         <SettingsProvider>
+            <HeadTitle />
             <Component {...pageProps} />
         </SettingsProvider>
     );

--- a/app/pages/maps/[mapUId].tsx
+++ b/app/pages/maps/[mapUId].tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import Head from "next/head";
 import { Layout } from "antd";
 import { useRouter } from "next/router";
 

--- a/app/pages/maps/[mapUId].tsx
+++ b/app/pages/maps/[mapUId].tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import Head from "next/head";
 import { Layout } from "antd";
 import { useRouter } from "next/router";
 
@@ -14,6 +15,7 @@ import {
     ReplayData,
     MapInfo,
 } from "../../lib/api/apiRequests";
+import { HeadTitle } from "../../components/common/HeadTitle";
 
 const Home = (): JSX.Element => {
     const [replays, setReplays] = useState<FileResponse[]>([]);
@@ -77,23 +79,26 @@ const Home = (): JSX.Element => {
     };
 
     return (
-        <Layout>
-            <MapHeader mapInfo={mapData} />
-            <Layout.Content>
-                <SidebarReplays
-                    mapUId={`${mapUId}`}
-                    replays={replays}
-                    onLoadReplay={onLoadReplay}
-                    onRemoveReplay={onRemoveReplay}
-                    onLoadAllVisibleReplays={onLoadAllVisibleReplays}
-                    onRemoveAllReplays={onRemoveAllReplays}
-                    selectedReplayDataIds={selectedReplayData.map((replay) => replay._id)}
-                    onRefreshReplays={fetchAndSetReplays}
-                />
-                <SidebarSettings />
-                <Viewer3D replaysData={selectedReplayData} />
-            </Layout.Content>
-        </Layout>
+        <>
+            <HeadTitle mapInfo={mapData} />
+            <Layout>
+                <MapHeader mapInfo={mapData} />
+                <Layout.Content>
+                    <SidebarReplays
+                        mapUId={`${mapUId}`}
+                        replays={replays}
+                        onLoadReplay={onLoadReplay}
+                        onRemoveReplay={onRemoveReplay}
+                        onLoadAllVisibleReplays={onLoadAllVisibleReplays}
+                        onRemoveAllReplays={onRemoveAllReplays}
+                        selectedReplayDataIds={selectedReplayData.map((replay) => replay._id)}
+                        onRefreshReplays={fetchAndSetReplays}
+                    />
+                    <SidebarSettings />
+                    <Viewer3D replaysData={selectedReplayData} />
+                </Layout.Content>
+            </Layout>
+        </>
     );
 };
 

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -34,3 +34,6 @@
 .ant-btn {
     line-height: 0.5 !important;
 }
+.ant-pagination-item-link {
+    line-height: 0.8 !important;
+}


### PR DESCRIPTION
Limited size of replay list by using a smaller number of replays, doesn't overflow on a regular size PC screen anymore.

Also added a page title for the homepage and for the map page:

![image](https://user-images.githubusercontent.com/22432233/119512981-19b3c580-bd74-11eb-8044-f5359c20c8f0.png)
