### PR TITLE
Move generic head into App

### DIFF
--- a/app/components/common/HeadTitle.tsx
+++ b/app/components/common/HeadTitle.tsx
@@ -14,18 +14,6 @@ const HeadTitle = ({ mapInfo }: HeadTitleProps): JSX.Element => {
 
     return (
         <Head>
-            <script async src="https://www.googletagmanager.com/gtag/js?id=G-0V30RMEPFN" />
-            <script
-                dangerouslySetInnerHTML={{
-                    __html: `
-                    window.dataLayer = window.dataLayer || [];
-                    function gtag(){dataLayer.push(arguments);}
-                    gtag('js', new Date());
-                
-                    gtag('config', 'G-0V30RMEPFN');
-                `,
-                }}
-            />
             <title>{pageTitle}</title>
         </Head>
     );

--- a/app/components/common/HeadTitle.tsx
+++ b/app/components/common/HeadTitle.tsx
@@ -1,16 +1,12 @@
 import React from 'react';
 import Head from 'next/head';
-import { MapInfo } from '../../lib/api/apiRequests';
-import { cleanTMFormatting } from '../../lib/utils/formatting';
 
 interface HeadTitleProps {
-    mapInfo?: MapInfo;
+    title?: string;
 }
 
-const HeadTitle = ({ mapInfo }: HeadTitleProps): JSX.Element => {
-    const mapName = mapInfo && mapInfo.name && cleanTMFormatting(mapInfo.name);
-
-    const pageTitle = `${mapName ? `${mapName} -` : ''} TMDojo`;
+const HeadTitle = ({ title }: HeadTitleProps): JSX.Element => {
+    const pageTitle = title || 'TMDojo';
 
     return (
         <Head>

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
+import Head from 'next/head';
 import HeadTitle from '../components/common/HeadTitle';
 import { SettingsProvider } from '../lib/contexts/SettingsContext';
 import '../styles/globals.css';
@@ -9,9 +10,31 @@ interface Props {
     pageProps: any;
 }
 
+const ANALYTICS_ID = process.env.NEXT_PUBLIC_ANALYTICS_ID;
+
 const App = ({ Component, pageProps }: Props): React.ReactElement => (
     <SettingsProvider>
-        <HeadTitle />
+        <Head>
+            {
+                ANALYTICS_ID && (
+                    <>
+                        <script async src={`https://www.googletagmanager.com/gtag/js?id=${ANALYTICS_ID}`} />
+                        <script
+                        // eslint-disable-next-line react/no-danger
+                            dangerouslySetInnerHTML={{
+                                __html: `
+                                        window.dataLayer = window.dataLayer || [];
+                                        function gtag(){dataLayer.push(arguments);}
+                                        gtag('js', new Date());
+                                        gtag('config', '${ANALYTICS_ID}');
+                                    `,
+                            }}
+                        />
+                    </>
+                )
+            }
+            <title>TMDojo</title>
+        </Head>
         <Component {...pageProps} />
     </SettingsProvider>
 );

--- a/app/pages/maps/[mapUId].tsx
+++ b/app/pages/maps/[mapUId].tsx
@@ -15,6 +15,7 @@ import {
     MapInfo,
 } from '../../lib/api/apiRequests';
 import HeadTitle from '../../components/common/HeadTitle';
+import { cleanTMFormatting } from '../../lib/utils/formatting';
 
 const Home = (): JSX.Element => {
     const [replays, setReplays] = useState<FileResponse[]>([]);
@@ -73,9 +74,11 @@ const Home = (): JSX.Element => {
         setSelectedReplayData(replayDataFiltered);
     };
 
+    const getTitle = () => (mapData?.name ? `${cleanTMFormatting(mapData.name)} - TMDojo` : 'TMDojo');
+
     return (
         <>
-            <HeadTitle mapInfo={mapData} />
+            <HeadTitle title={getTitle()} />
             <Layout>
                 <MapHeader mapInfo={mapData} />
                 <Layout.Content>


### PR DESCRIPTION
- Moved analytics and base title into App.
- Kept specific title in HeadTitle - but moved title assembly into the panel so HeadTitle can be reused later.
- Added env var for Google Analytics.