### PR TITLE
Refactor data model (and extract map and user references)

### DIFF
--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -192,7 +192,8 @@ const getReplays = (
     addRegexFilter(mapName, 'mapName');
     addRegexFilter(playerName, 'playerName');
     addRegexFilter(mapUId, 'mapUId');
-    if (raceFinished) {
+
+    if (raceFinished && raceFinished !== '-1') {
         pipeline.push({
             $match: {
                 raceFinished: parseInt(raceFinished, 10),
@@ -200,7 +201,7 @@ const getReplays = (
         });
     }
 
-    if (orderBy) {
+    if (orderBy && orderBy !== 'None') {
         const order = {};
         if (orderBy === 'Time Desc') {
             order.endRaceTime = -1;

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -123,9 +123,11 @@ const getMapByUId = (mapUId) => new Promise((resolve, reject) => {
     });
 });
 
-const saveMap = (mapData) => new Promise((resolve) => {
+const saveMap = (mapData) => new Promise((resolve, reject) => {
     const maps = db.collection('maps');
-    maps.insertOne(mapData).then((operation) => resolve({ _id: operation?.insertedId }));
+    maps.insertOne(mapData)
+        .then((operation) => resolve({ _id: operation?.insertedId }))
+        .catch((error) => reject(error));
 });
 
 const getUserByWebId = (webId) => new Promise((resolve, reject) => {
@@ -138,9 +140,11 @@ const getUserByWebId = (webId) => new Promise((resolve, reject) => {
     });
 });
 
-const saveUser = (userData) => new Promise((resolve) => {
+const saveUser = (userData) => new Promise((resolve, reject) => {
     const users = db.collection('users');
-    users.insertOne(userData).then((operation) => resolve({ _id: operation?.insertedId }));
+    users.insertOne(userData)
+        .then((operation) => resolve({ _id: operation?.insertedId }))
+        .catch((error) => reject(error));
 });
 
 const getReplays = (
@@ -308,9 +312,11 @@ const getReplayByFilePath = (filePath) => new Promise((resolve, reject) => {
     });
 });
 
-const saveReplayMetadata = (metadata) => new Promise((resolve) => {
+const saveReplayMetadata = (metadata) => new Promise((resolve, reject) => {
     const replays = db.collection('replays');
-    replays.insertOne(metadata).then((operation) => resolve({ _id: operation?.insertedId }));
+    replays.insertOne(metadata)
+        .then((operation) => resolve({ _id: operation?.insertedId }))
+        .catch((error) => reject(error));
 });
 
 module.exports = {

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -24,30 +24,30 @@ const authenticateUser = (webId, login, name) => new Promise((resolve, reject) =
     const users = db.collection('users');
     users
         .find({
-            webid: webId,
+            webId,
         })
         .toArray((err, docs) => {
             if (err) {
                 reject(err);
             } else if (!docs.length) {
                 users.insertOne({
-                    webid: webId,
-                    login,
-                    name,
+                    webId,
+                    playerLogin: login,
+                    playerName: name,
                     last_active: Date.now(),
                 });
                 resolve();
             } else {
                 const updatedUser = {
                     $set: {
-                        login,
-                        name,
+                        playerLogin: login,
+                        playerName: name,
                         last_active: Date.now(),
                     },
                 };
                 users.updateOne(
                     {
-                        webid: webId,
+                        webId,
                     },
                     updatedUser,
                 );
@@ -56,15 +56,21 @@ const authenticateUser = (webId, login, name) => new Promise((resolve, reject) =
         });
 });
 
-const saveReplayMetadata = (metadata) => new Promise((resolve) => {
-    const raceData = db.collection('race_data');
-    raceData.insertOne(metadata);
-    resolve();
-});
-
 const getUniqueMapNames = (mapName) => new Promise((resolve, reject) => {
-    const raceData = db.collection('race_data');
+    const replays = db.collection('replays');
     const queryPipeline = [
+        // populate map references to count occurrences
+        {
+            $lookup: {
+                from: 'maps',
+                localField: 'mapRef',
+                foreignField: '_id',
+                as: 'map',
+            },
+        },
+        {
+            $replaceRoot: { newRoot: { $mergeObjects: [{ $arrayElemAt: ['$map', 0] }, '$$ROOT'] } },
+        },
         {
             $group: {
                 _id: '$mapUId',
@@ -88,13 +94,13 @@ const getUniqueMapNames = (mapName) => new Promise((resolve, reject) => {
 
     // only filter by name if there's valid input
     if (mapName && mapName !== '') {
-        queryPipeline.unshift({
+        queryPipeline.push({
             $match: {
                 mapName: { $regex: `.*${mapName}.*`, $options: 'i' },
             },
         });
     }
-    raceData.aggregate(queryPipeline, async (aggregateErr, cursor) => {
+    replays.aggregate(queryPipeline, async (aggregateErr, cursor) => {
         if (aggregateErr) {
             return reject(aggregateErr);
         }
@@ -107,85 +113,203 @@ const getUniqueMapNames = (mapName) => new Promise((resolve, reject) => {
     });
 });
 
-const getReplays = (
-    mapName = '', playerName = '', mapUId = '', raceFinished = '-1', orderBy = 'None', maxResults = '1000',
-) => new Promise((resolve, reject) => {
-    const raceData = db.collection('race_data');
-    const query = {};
-    // case-insensitive filter for map and player name
-    if (mapName.length > 0) {
-        query.mapName = {
-            $regex: `.*${mapName}.*`,
-            $options: 'i',
-        };
-    }
-    if (playerName.length > 0) {
-        query.playerName = {
-            $regex: `.*${playerName}.*`,
-            $options: 'i',
-        };
-    }
-    if (mapUId.length > 0) {
-        query.mapUId = {
-            $regex: `.*${mapUId}.*`,
-        };
-    }
-    if (raceFinished !== '-1') {
-        query.raceFinished = parseInt(raceFinished, 10);
-    }
-    const order = {};
-    if (orderBy.length > 0) {
-        if (orderBy === 'Time Desc') {
-            order.endRaceTime = -1;
-        }
-        if (orderBy === 'Time Asc') {
-            order.endRaceTime = 1;
-        }
-        if (orderBy === 'Date Desc') {
-            order.date = -1;
-        }
-        if (orderBy === 'Date Asc') {
-            order.date = 1;
-        }
-    }
-    raceData
-        .find(query)
-        .sort(order)
-        .toArray((err, docs) => {
-            if (err) {
-                return reject(err);
-            }
-            const files = [];
-            for (let i = 0; i < Number(maxResults) && i < docs.length; i++) {
-                const doc = docs[i];
-                delete doc.file_path; // remove file_path because it's just internal structure
-                files.push(doc);
-            }
-            return resolve({
-                files,
-                totalResults: docs.length,
-            });
-        });
-});
-
-const getReplayById = (replayId) => new Promise((resolve, reject) => {
-    const raceData = db.collection('race_data');
-    raceData.findOne({ _id: ObjectID(replayId) }, (err, replay) => {
+const getMapByUId = (mapUId) => new Promise((resolve, reject) => {
+    const maps = db.collection('maps');
+    maps.findOne({ mapUId }, (err, map) => {
         if (err) {
             return reject(err);
         }
-        return resolve(replay);
+        return resolve(map);
+    });
+});
+
+const saveMap = (mapData) => new Promise((resolve) => {
+    const maps = db.collection('maps');
+    maps.insertOne(mapData).then((operation) => resolve({ _id: operation?.insertedId }));
+});
+
+const getUserByWebId = (webId) => new Promise((resolve, reject) => {
+    const users = db.collection('users');
+    users.findOne({ webId }, (err, user) => {
+        if (err) {
+            return reject(err);
+        }
+        return resolve(user);
+    });
+});
+
+const saveUser = (userData) => new Promise((resolve) => {
+    const users = db.collection('users');
+    users.insertOne(userData).then((operation) => resolve({ _id: operation?.insertedId }));
+});
+
+const getReplays = (
+    mapName, playerName, mapUId, raceFinished, orderBy, maxResults = '1000',
+) => new Promise((resolve, reject) => {
+    const replays = db.collection('replays');
+
+    const pipeline = [
+        // populate user references
+        {
+            $lookup: {
+                from: 'users',
+                localField: 'userRef',
+                foreignField: '_id',
+                as: 'user',
+            },
+        },
+        {
+            $replaceRoot: { newRoot: { $mergeObjects: [{ $arrayElemAt: ['$user', 0] }, '$$ROOT'] } },
+        },
+        // populate map references
+        {
+            $lookup: {
+                from: 'maps',
+                localField: 'mapRef',
+                foreignField: '_id',
+                as: 'map',
+            },
+        },
+        {
+            $replaceRoot: { newRoot: { $mergeObjects: [{ $arrayElemAt: ['$map', 0] }, '$$ROOT'] } },
+        },
+    ];
+
+    const addRegexFilter = (property, propertyName) => {
+        if (property) {
+            pipeline.push({
+                $match: {
+                    [propertyName]: {
+                        $regex: `.*${property}.*`,
+                        $options: 'i',
+                    },
+                },
+            });
+        }
+    };
+
+    // apply filters
+    addRegexFilter(mapName, 'mapName');
+    addRegexFilter(playerName, 'playerName');
+    addRegexFilter(mapUId, 'mapUId');
+    if (raceFinished) {
+        pipeline.push({
+            $match: {
+                raceFinished: parseInt(raceFinished, 10),
+            },
+        });
+    }
+
+    if (orderBy) {
+        const order = {};
+        if (orderBy === 'Time Desc') {
+            order.endRaceTime = -1;
+        } else if (orderBy === 'Time Asc') {
+            order.endRaceTime = 1;
+        } else if (orderBy === 'Date Desc') {
+            order.date = -1;
+        } else if (orderBy === 'Date Asc') {
+            order.date = 1;
+        }
+        pipeline.push({
+            $sort: order,
+        });
+    }
+
+    // add limit and clean up results
+    pipeline.push({
+        $limit: parseInt(maxResults, 10),
+    });
+    pipeline.push({
+        $project: {
+            userRef: 0, user: 0, mapRef: 0, map: 0, filePath: 0,
+        },
+    });
+
+    replays.aggregate(pipeline, async (aggregateErr, cursor) => {
+        if (aggregateErr) {
+            return reject(aggregateErr);
+        }
+        try {
+            const data = await cursor.toArray();
+            return resolve({ files: data, totalResults: data.length });
+        } catch (arrayErr) {
+            return reject(arrayErr);
+        }
+    });
+});
+
+const getReplayById = (replayId, populate) => new Promise((resolve, reject) => {
+    const replays = db.collection('replays');
+
+    let pipeline = [
+        {
+            $match: { _id: ObjectID(replayId) },
+        },
+    ];
+
+    if (populate) {
+        pipeline = pipeline.concat([
+            // populate user references
+            {
+                $lookup: {
+                    from: 'users',
+                    localField: 'userRef',
+                    foreignField: '_id',
+                    as: 'user',
+                },
+            },
+            {
+                $replaceRoot: { newRoot: { $mergeObjects: [{ $arrayElemAt: ['$user', 0] }, '$$ROOT'] } },
+            },
+            // populate map references
+            {
+                $lookup: {
+                    from: 'maps',
+                    localField: 'mapRef',
+                    foreignField: '_id',
+                    as: 'map',
+                },
+            },
+            {
+                $replaceRoot: { newRoot: { $mergeObjects: [{ $arrayElemAt: ['$map', 0] }, '$$ROOT'] } },
+            },
+            // clean up
+            {
+                $project: {
+                    // don't remove filePath since it's needed in the request
+                    userRef: 0, user: 0, mapRef: 0, map: 0,
+                },
+            },
+        ]);
+    }
+
+    replays.aggregate(pipeline, async (aggregateErr, cursor) => {
+        if (aggregateErr) {
+            return reject(aggregateErr);
+        }
+        try {
+            const data = await cursor.toArray();
+            return resolve(data[0]);
+        } catch (arrayErr) {
+            return reject(arrayErr);
+        }
     });
 });
 
 const getReplayByFilePath = (filePath) => new Promise((resolve, reject) => {
-    const raceData = db.collection('race_data');
-    raceData.findOne({ file_path: filePath }, (err, replay) => {
+    const replays = db.collection('replays');
+    replays.findOne({ filePath }, (err, replay) => {
         if (err) {
             return reject(err);
         }
         return resolve(replay);
     });
+});
+
+const saveReplayMetadata = (metadata) => new Promise((resolve) => {
+    const replays = db.collection('replays');
+    replays.insertOne(metadata).then((operation) => resolve({ _id: operation?.insertedId }));
 });
 
 module.exports = {
@@ -193,6 +317,10 @@ module.exports = {
     authenticateUser,
     saveReplayMetadata,
     getUniqueMapNames,
+    getMapByUId,
+    saveMap,
+    getUserByWebId,
+    saveUser,
     getReplays,
     getReplayById,
     getReplayByFilePath,

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,3 +1,10 @@
+/** User data model
+ * - _id
+ * - webId
+ * - playerLogin
+ * - playerName
+ */
+
 const express = require('express');
 
 const router = express.Router();

--- a/server/routes/maps.js
+++ b/server/routes/maps.js
@@ -1,3 +1,11 @@
+/** Map data model
+ * - _id
+ * - mapName
+ * - mapUId
+ * - authorName
+ * - thumbnailURL (not implemented yet)
+ */
+
 const express = require('express');
 
 const router = express.Router();

--- a/server/routes/replays.js
+++ b/server/routes/replays.js
@@ -121,7 +121,23 @@ router.get('/:replayId/export', async (req, res, next) => {
  * - playerLogin
  * - webId
  */
+// eslint-disable-next-line consistent-return
 router.post('/', (req, res, next) => {
+    const paramNames = [
+        'authorName', 'mapName', 'mapUId', 'endRaceTime', 'raceFinished', 'playerName', 'playerLogin', 'webId',
+    ];
+
+    // make sure all required parameters are present
+    let requestValid = true;
+    paramNames.forEach((paramName) => {
+        if (!req.query[paramName]) {
+            requestValid = false;
+        }
+    });
+    if (!requestValid) {
+        return res.status(400).send({ message: 'Request is missing one or more parameters' });
+    }
+
     // prepare directories
     if (!fs.existsSync(`maps/${req.query.authorName}`)) {
         fs.mkdirSync(`maps/${req.query.authorName}`);
@@ -184,9 +200,7 @@ router.post('/', (req, res, next) => {
         });
     });
 
-    req.on('error', (err) => {
-        next(err);
-    });
+    req.on('error', (err) => next(err));
 });
 
 /**

--- a/server/routes/replays.js
+++ b/server/routes/replays.js
@@ -130,7 +130,7 @@ router.post('/', (req, res, next) => {
     // make sure all required parameters are present
     let requestValid = true;
     paramNames.forEach((paramName) => {
-        if (!req.query[paramName]) {
+        if (!Object.prototype.hasOwnProperty.call(req.query, paramName)) {
             requestValid = false;
         }
     });

--- a/server/routes/replays.js
+++ b/server/routes/replays.js
@@ -1,3 +1,13 @@
+/** Replay data model
+ * - _id
+ * - userRef
+ * - mapRef
+ * - endRaceTime
+ * - raceFinished
+ * - filePath
+ * - date
+ */
+
 const express = require('express');
 
 const router = express.Router();
@@ -47,7 +57,7 @@ router.get('/', async (req, res, next) => {
 router.get('/:replayId', async (req, res, next) => {
     try {
         const replay = await db.getReplayById(req.params.replayId);
-        const filePath = path.resolve(`${__dirname}/../${replay.file_path}`);
+        const filePath = path.resolve(`${__dirname}/../${replay.filePath}`);
         if (fs.existsSync(filePath)) {
             if (req.query.download === 'true') {
                 res.download(filePath, req.query.fileName || req.params.replayId);
@@ -65,19 +75,18 @@ router.get('/:replayId', async (req, res, next) => {
 /**
  * GET /replays/:replayId/export
  * Exports a replay file including its metadata
- * Query params:
  */
 router.get('/:replayId/export', async (req, res, next) => {
     try {
-        const replay = await db.getReplayById(req.params.replayId);
-        const filePath = path.resolve(`${__dirname}/../${replay.file_path}`);
+        const replay = await db.getReplayById(req.params.replayId, true);
+        const filePath = path.resolve(`${__dirname}/../${replay.filePath}`);
         if (fs.existsSync(filePath)) {
             const contents = fs.readFileSync(filePath, {
                 encoding: 'base64',
             });
             replay.base64 = contents;
             delete replay._id; // remove id so importing can't lead to conflicts
-            delete replay.file_path; // remove file_path because it's just internal structure
+            delete replay.filePath; // remove filePath because it's just internal structure
 
             const fileData = JSON.stringify(replay);
             const fileName = `${req.params.replayId}.json`;
@@ -138,9 +147,31 @@ router.post('/', (req, res, next) => {
             console.log('POST /replays: The file was saved at', filePath);
 
             try {
+                // check if map already exists
+                let map = await db.getMapByUId(req.query.mapUId);
+                if (!map) {
+                    map = await db.saveMap({
+                        mapName: req.query.mapName,
+                        mapUId: req.query.mapUId,
+                        authorName: req.query.authorName,
+                    });
+                }
+
+                // check if user already exists
+                let user = await db.getUserByWebId(req.query.webId);
+                if (!user) {
+                    user = await db.saveUser({
+                        playerName: req.query.playerName,
+                        playerLogin: req.query.playerLogin,
+                        webId: req.query.webId,
+                    });
+                }
+
                 const metadata = {
-                    ...req.query,
-                    file_path: filePath,
+                    // reference map and user docs
+                    mapRef: map._id,
+                    userRef: user._id,
+                    filePath,
                     date: Date.now(),
                     raceFinished: parseInt(req.query.raceFinished, 10),
                     endRaceTime: parseInt(req.query.endRaceTime, 10),
@@ -189,27 +220,47 @@ router.post('/import', (req, res, next) => {
         // check if exact filepath is already in db (this assume db is synced with file system)
         const replay = await db.getReplayByFilePath(filePath);
         if (!replay) {
-            const replayMetadata = {
-                mapName: importData.mapName,
-                mapUId: importData.mapUId,
-                authorName: importData.authorName,
-                playerName: importData.playerName,
-                playerLogin: importData.playerLogin,
-                webId: importData.webId,
-                endRaceTime: importData.endRaceTime,
-                raceFinished: importData.raceFinished,
-                file_path: filePath,
-                date: importData.date,
-            };
-            await db.saveReplayMetadata(replayMetadata);
-
             const buffer = Buffer.from(importData.base64, 'base64');
-            fs.writeFile(filePath, buffer, (err) => {
+            fs.writeFile(filePath, buffer, async (err) => {
                 if (err) {
-                    next(err);
-                } else {
-                    console.log('POST /replays/import: The file was saved at', filePath);
-                    res.send();
+                    return next(err);
+                }
+                console.log('POST /replays/import: The file was saved at', filePath);
+
+                // TODO: clean this up since it's basically the same as for POST /replays
+                try {
+                    // check if map already exists
+                    let map = await db.getMapByUId(importData.mapUId);
+                    if (!map) {
+                        map = await db.saveMap({
+                            mapName: importData.mapName,
+                            mapUId: importData.mapUId,
+                            authorName: importData.authorName,
+                        });
+                    }
+
+                    // check if user already exists
+                    let user = await db.getUserByWebId(importData.webId);
+                    if (!user) {
+                        user = await db.saveUser({
+                            playerName: importData.playerName,
+                            playerLogin: importData.playerLogin,
+                            webId: req.query.webId,
+                        });
+                    }
+
+                    const metadata = {
+                        mapRef: map._id,
+                        userRef: user._id,
+                        filePath,
+                        date: Date.now(),
+                        raceFinished: parseInt(importData.raceFinished, 10),
+                        endRaceTime: parseInt(importData.endRaceTime, 10),
+                    };
+                    await db.saveReplayMetadata(metadata);
+                    return res.send();
+                } catch (dbErr) {
+                    return next(dbErr);
                 }
             });
         } else {


### PR DESCRIPTION
- Renamed `race_data` collection to `replays`.
- Changed a bunch of stuff in the data model - see the top of each route file for the new ones.
  - users
    - webid -> webId
    - name -> playerName
    - login -> playerLogin
  - replays
    - file_path -> filePath
    - Removed map and user fields and replaced them with mapRef and userRef.
- Added logic to handle map and user data for `POST /replays` and the import route (currently duplicate code, but I'm not even sure we want to keep export/import so I didn't spend any effort yet).
- Added query logic for `GET` requests to populate the map and user references when needed.
- While I was working on the API, I added a safety check for replay submissions to reject all requests that were missing required query parameters.

Migration script for local env (and production once we push it there): https://gist.github.com/davidbmaier/604b9e90da856969d8e138eabfb48339
Script is also already on the production machine for later (`~/migrate`).