### PR TITLE
Remove invalid sessionId cookies

### DIFF
--- a/server/lib/authorize.js
+++ b/server/lib/authorize.js
@@ -63,8 +63,28 @@ const playerLoginFromWebId = (webId) => {
     }
 };
 
+const setSessionCookieWithAge = (res, sessionId, age) => {
+    res.cookie('sessionId', sessionId, {
+        path: '/',
+        secure: false, // TODO: enable on HTTPS server
+        maxAge: age,
+        domain: process.env.NODE_ENV === 'prod' ? 'tmdojo.com' : 'localhost',
+    });
+};
+
+const setSessionCookie = (res, sessionId) => {
+    const age = 1000 * 60 * 60 * 24 * 365; // 365 days
+    setSessionCookieWithAge(res, sessionId, age);
+};
+
+const setExpiredSessionCookie = (res) => {
+    setSessionCookieWithAge(res, '', -1);
+};
+
 module.exports = {
     exchangeCodeForAccessToken,
     fetchUserInfo,
     playerLoginFromWebId,
+    setSessionCookie,
+    setExpiredSessionCookie,
 };

--- a/server/routes/authorize.js
+++ b/server/routes/authorize.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { exchangeCodeForAccessToken, fetchUserInfo } = require('../lib/authorize');
+const { exchangeCodeForAccessToken, fetchUserInfo, setSessionCookie } = require('../lib/authorize');
 const { createSession } = require('../lib/db');
 
 const router = express.Router();
@@ -50,13 +50,7 @@ router.post('/', async (req, res, next) => {
             return;
         }
 
-        // Repond with user info
-        res.cookie('sessionId', sessionId, {
-            path: '/',
-            secure: false, // TODO: enable on HTTPS server
-            maxAge: 1000 * 60 * 60 * 24 * 365, // 365 days
-            domain: process.env.NODE_ENV === 'prod' ? 'tmdojo.com' : 'localhost',
-        });
+        setSessionCookie(res, sessionId);
 
         res.send({
             accountId: userInfo.account_id,

--- a/server/routes/logout.js
+++ b/server/routes/logout.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { setExpiredSessionCookie } = require('../lib/authorize');
 const { deleteSession, findSessionBySecret } = require('../lib/db');
 
 const router = express.Router();
@@ -20,22 +21,15 @@ router.post('/', async (req, res, next) => {
         // Check if the session exists
         const session = await findSessionBySecret(sessionId);
         if (session === null || session === undefined) {
+            setExpiredSessionCookie(res);
             res.status(401).send({ message: 'No session found for this secret.' });
             return;
         }
 
-        // Send instantly expiring cookie
-        res.cookie('sessionId', sessionId, {
-            path: '/',
-            secure: false, // TODO: enable on HTTPS server
-            maxAge: -1, // instantly expires
-            domain: process.env.NODE_ENV === 'prod' ? 'tmdojo.com' : 'localhost',
-        });
-
-        // Delete session
         await deleteSession(sessionId);
 
-        // Repond with user info
+        setExpiredSessionCookie(res);
+
         res.status(200).end();
     } catch (err) {
         next(err);

--- a/server/routes/me.js
+++ b/server/routes/me.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { setExpiredSessionCookie } = require('../lib/authorize');
 
 const router = express.Router();
 
@@ -12,6 +13,7 @@ router.post('/', async (req, res, next) => {
 
         // Get user by session secret
         if (user === undefined) {
+            setExpiredSessionCookie(res);
             res.status(401).send({ message: 'Not logged in.' });
             return;
         }


### PR DESCRIPTION
Changes to the following endpoints:
* `/logout`: if no session is found with the provided `sessionId`, respond with an instantly expiring cookie
* `/me`: if no user is found with the provided `sessionId`, respond with an instantly expiring cookie

This tries to make sure that the client will not have a `sessionId` cookie stored that isn't connected to a valid session/user