### PR TITLE
Use custom axios instance

### DIFF
--- a/app/lib/api/apiInstance.ts
+++ b/app/lib/api/apiInstance.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const apiInstance = axios.create({
+    baseURL: process.env.NEXT_PUBLIC_API_URL,
+    withCredentials: true,
+});
+
+export default apiInstance;

--- a/app/lib/api/apiRequests.ts
+++ b/app/lib/api/apiRequests.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import apiInstance from './apiInstance';
 import { readDataView, DataViewResult } from '../replays/replayData';
 
 interface FilterParams {
@@ -44,9 +44,8 @@ const DEFAULT_FILTERS = {
 };
 
 export const getReplays = async (filters: FilterParams = DEFAULT_FILTERS): Promise<FilesResult> => {
-    const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/replays`, {
+    const res = await apiInstance.get('/replays', {
         params: { ...DEFAULT_FILTERS, ...filters },
-        withCredentials: true,
     });
 
     return res.data;
@@ -54,7 +53,7 @@ export const getReplays = async (filters: FilterParams = DEFAULT_FILTERS): Promi
 
 export interface ReplayData extends FileResponse, DataViewResult {}
 export const fetchReplayData = async (file: FileResponse): Promise<ReplayData> => {
-    const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/replays/${file._id}`, {
+    const res = await apiInstance.get(`/replays/${file._id}`, {
         responseType: 'arraybuffer',
     });
 
@@ -80,9 +79,7 @@ export type MapInfo = {
 };
 
 export const getMapInfo = async (mapUId: string): Promise<MapInfo> => {
-    const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/maps/${mapUId}/info`, {
-        withCredentials: true,
-    });
+    const res = await apiInstance.get(`/maps/${mapUId}/info`);
     return res.data;
 };
 
@@ -94,11 +91,10 @@ export type AvailableMap = {
 };
 
 export const getAvailableMaps = async (searchString: string): Promise<AvailableMap[]> => {
-    const res = await axios.get(
-        `${process.env.NEXT_PUBLIC_API_URL}/maps${searchString ? `?mapName=${searchString}` : ''}`,
-        {
-            withCredentials: true,
+    const res = await apiInstance.get('/maps', {
+        params: {
+            mapName: searchString,
         },
-    );
+    });
     return res.data;
 };

--- a/app/lib/api/auth.ts
+++ b/app/lib/api/auth.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import apiInstance from './apiInstance';
 
 const getRedirectUri = () => {
     if (typeof window === 'undefined') {
@@ -26,15 +27,12 @@ interface AuthorizationResponse {
     accountId: string;
 }
 export const authorizeWithAccessCode = async (accessCode: string): Promise<AuthorizationResponse> => {
-    const url = `${process.env.NEXT_PUBLIC_API_URL}/authorize`;
-
     const params = {
         code: accessCode,
         redirect_uri: getRedirectUri(),
     };
 
-    // TODO: use custom axios instance with default config for withCredentials
-    const { data } = await axios.post(url, params, { withCredentials: true });
+    const { data } = await apiInstance.post('/authorize', params, { withCredentials: true });
 
     return data;
 };
@@ -44,8 +42,6 @@ export interface UserInfo {
     accountId: string;
 }
 export const fetchLoggedInUser = async (): Promise<UserInfo | undefined> => {
-    const url = `${process.env.NEXT_PUBLIC_API_URL}/me`;
-
     const hasSessionCookie = document.cookie
         .split(';')
         .filter((cookie) => cookie.trim().startsWith('sessionId='))
@@ -56,8 +52,7 @@ export const fetchLoggedInUser = async (): Promise<UserInfo | undefined> => {
     }
 
     try {
-        // TODO: use custom axios instance with default config for withCredentials
-        const { data } = await axios.post(url, {}, { withCredentials: true });
+        const { data } = await apiInstance.post('/me');
         return data;
     } catch (e) {
         // TODO: find solution for being logged out on a server error?
@@ -66,8 +61,5 @@ export const fetchLoggedInUser = async (): Promise<UserInfo | undefined> => {
 };
 
 export const logout = async (): Promise<void> => {
-    const url = `${process.env.NEXT_PUBLIC_API_URL}/logout`;
-
-    // TODO: use custom axios instance with default config for withCredentials
-    await axios.post(url, {}, { withCredentials: true });
+    await apiInstance.post('/logout');
 };


### PR DESCRIPTION
Adds a custom axios instance:
- `baseUrl` set to `.env` API url
- `withCredentials` true by default