### PR TITLE
Implement initial plugin auth on server and app

### DIFF
--- a/app/lib/api/auth.ts
+++ b/app/lib/api/auth.ts
@@ -1,10 +1,14 @@
 import axios from 'axios';
 import apiInstance from './apiInstance';
 
-const getRedirectUri = () => {
+const getRedirectUri = (isPluginAuth?: any) => {
     if (typeof window === 'undefined') {
         // Avoid some nextjs compilation errors regarding window being undefined
         return undefined;
+    }
+    // TODO: clean this up a bit - plugin auth requires a different redirectURI
+    if (isPluginAuth) {
+        return `${window.location.origin}/auth_redirect_plugin`;
     }
     return `${window.location.origin}/auth_redirect`;
 };
@@ -26,11 +30,19 @@ interface AuthorizationResponse {
     displayName: string;
     accountId: string;
 }
-export const authorizeWithAccessCode = async (accessCode: string): Promise<AuthorizationResponse> => {
+export const authorizeWithAccessCode = async (
+    accessCode: string, clientCode?: string,
+): Promise<AuthorizationResponse> => {
     const params = {
         code: accessCode,
-        redirect_uri: getRedirectUri(),
+        redirect_uri: getRedirectUri(!!clientCode),
+        clientCode,
     };
+
+    if (!clientCode) {
+        // make sure clientCode is only sent if it exists
+        delete params.clientCode;
+    }
 
     const { data } = await apiInstance.post('/authorize', params, { withCredentials: true });
 

--- a/app/pages/auth_redirect_plugin/index.tsx
+++ b/app/pages/auth_redirect_plugin/index.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { Card, Layout, Spin } from 'antd';
+import { authorizeWithAccessCode } from '../../lib/api/auth';
+
+const AuthRedirectPlugin = (): JSX.Element => {
+    const router = useRouter();
+    const { code, state } = router.query;
+
+    // TODO: move this into the AuthContext, and potentially merge this with auth_redirect (keeping both routes though)
+    useEffect(() => {
+        const authorize = async () => {
+            if (
+                code !== undefined && typeof code === 'string'
+                && state !== undefined && typeof state === 'string'
+            ) {
+                try {
+                    // TODO: handle this response - this should be handled like the normal UI login
+                    // it responds with a normal UI session (so the user doesn't have to log in again in the future)
+                    await authorizeWithAccessCode(code, state);
+                } catch (e) {
+                    console.log(e);
+                }
+            }
+        };
+
+        authorize();
+    }, [code, state]);
+
+    return (
+        <Layout>
+            <Layout.Content className="w-4/5 m-auto h-full flex flex-col pt-8">
+                <Card
+                    className="w-full align-center"
+                    title="You can close this window and return to the game now..."
+                >
+                    <Spin />
+                </Card>
+            </Layout.Content>
+        </Layout>
+    );
+};
+
+export default AuthRedirectPlugin;

--- a/server/.env.template
+++ b/server/.env.template
@@ -3,8 +3,10 @@ NODE_ENV=[prod or dev]
 USE_CERTIFICATES=[true or false]
 MONGO_URL=[mongodb://localhost:PORT]
 
-HTTP_PORT=number
-HTTPS_PORT=number
+TMDOJO_UI_URL=<Base URL for the TMDojo UI>
+
+HTTP_PORT=[number]
+HTTPS_PORT=[number]
 
 TM_API_CLIENT_ID=<CLIENT_ID from api.trackmania.com>
 TM_API_CLIENT_SECRET=<CLIENT_SECRET from api.trackmania.com>

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -3,10 +3,12 @@
  * - webId
  * - playerLogin
  * - playerName
+ * - clientCode (optional, only used during plugin auth flow)
  */
 
 import { Request, Response } from 'express';
 import * as express from 'express';
+import { v4 as uuid } from 'uuid';
 
 import * as db from '../lib/db';
 
@@ -14,7 +16,8 @@ const router = express.Router();
 
 /**
  * GET /auth
- * Authenticates a user (i.e. stores them in the database for later use)
+ * Adds user to the database (if they don't exist)
+ * Generates a clientCode (and stores it in the user) and returns an OAuth login URL
  * Query params:
  * - webid
  * - login
@@ -22,8 +25,45 @@ const router = express.Router();
  */
 router.get('/', async (req: Request, res: Response, next: Function) => {
     try {
-        await db.authenticateUser(req.query.webid, req.query.login, req.query.name);
-        res.send('auth done'); // TODO: the plugin expects text for some reason - it should just check the return code
+        // generate clientCode
+        const clientCode = uuid();
+
+        // make sure user exists and store clientCode in user's document
+        await db.authenticateUser(req.query.webid, req.query.login, req.query.name, clientCode);
+
+        // generate OAuth URL
+        let authURL = 'https://api.trackmania.com/oauth/authorize';
+        authURL += '?response_type=code';
+        authURL += `&client_id=${process.env.TM_API_CLIENT_ID}`;
+        authURL += `&redirect_uri=${encodeURIComponent(`${process.env.TMDOJO_UI_URL}/auth_redirect_plugin`)}`;
+        authURL += `&state=${clientCode}`;
+
+        res.send({ authURL, clientCode });
+    } catch (err) {
+        next(err);
+    }
+});
+
+/**
+ * GET /auth
+ * Returns session for client (last step in the plugin auth flow)
+ * Query params:
+ * - clientCode
+ */
+router.get('/pluginSecret', async (req: Request, res: Response, next: Function) => {
+    try {
+        const { clientCode } = req.query;
+
+        const session = await db.findSessionByClientCode(clientCode.toString());
+        // TODO: maybe also make the plugin send a user that we can check against - just to be sure it's the same user
+        if (session) {
+            res.send({ sessionId: session.sessionId });
+            // remove clientCode from the session again (so it can't be reused)
+            delete session.clientCode;
+            await db.updateSession(session);
+        } else {
+            res.status(400).send();
+        }
     } catch (err) {
         next(err);
     }


### PR DESCRIPTION
This is just an initial implementation, and there's still a few TODOs for cleanup and improvements.
But this basically covers all of the essential parts for server and UI parts of the planned plugin auth flow (see diagram below for a rough overview).

![image](https://user-images.githubusercontent.com/17618532/132125998-9f0f2343-f361-4276-80fb-fe3feaaeec29.png)

Let me know if you got any questions/concerns - this is obviously a bit complex, and I might create a proper diagram at some point if we need it.

### Conventions
- `sessionId` or the session secret is the session's identifier that's stored in our database. This is what we need to get to the client/game so it can prove its identity to us in the future (primarily to upload replays).
- `clientCode` ("tempCode" in the diagram) is the temporary code generated by our server that identifies a client/game. It's used to retrieve the session after the user has logged in and proven his identity. After the plugin has retrieved the session, this code loses its meaning and can be removed from memory.
- `code` or "auth code" is part of the standardized OAuth flow. The code is generated by the trackmania.com API, and we only send it around - we don't store it or modify it because it doesn't have any meaning to us. It is what proves to the trackmania.com API that the user has indeed logged in from our site, so it sends us the actual access token (which we then use to retrieve the real user data from trackmania.com) proving to us the user is who they say they are.

### Server
- Modified `/auth` route to generate `clientCode` and store it in the user document for later. Also changed response to now include that `clientCode` and the URL to log in on trackmania.com (including a dedicated `redirect_uri` and the `clientCode` inside the `state` query parameter).
- Added `TMDOJO_UI_URL` env variable to be able to generate the correct `redirect_uri` - we'll have to always set that, but we could probably also define intelligent fallbacks in the future.
- Modified `/authorize` route to also accept the `clientCode`. If it exists, check that the user's `clientCode` in the database and the one in the request are the same. If so, create an extra session and include the `clientCode` in there (so it can later be retrieved by the plugin). Also remove the `clientCode` from the user document so it can't be used again.
Note that a "normal" session is created either way - so the existing login flow still works. At the same time, the plugin auth flow will also return a "normal" UI session to the `redirect_uri`, so the user won't have to log in again if they visit the normal UI later.
- Added `/auth/pluginSecret` route to retrieve a session by its associated `clientCode`. If one is found, it responds with the `sessionId` so the plugin can store it. Also, the `clientCode` is removed from the session document in the database so it can't be used again (at this point, the server forgets about the `clientCode`).

### UI
- Added `/auth_redirect_plugin` route to serve as `redirect_uri` for the plugin auth flow. I just copied over the structure from the existing redirect target, and we should probably consolidate the two down the line (keeping both routes if possible).
It sends both auth code and the state (i.e. the `clientCode`) to the server's `/authorize` route but doesn't do anything with the response yet. As mentioned before, the server also creates a normal UI session so that could be received and processed here.
- Added some logic to include `clientCode` handling where necessary in the UI's auth logic.

### Plugin
Nothing has been done here yet, so here's the TODOs:
- Add a settings menu to initiate the login flow (and obviously don't attempt to submit any replays if the plugin doesn't know about any sessions). I assume the plugin would call the `/auth` route at startup if it doesn't have a session secret locally - and store the returned URL and `clientCode` in memory. The menu could then include a simple button to open the URL in a browser window.
- After the button has been clicked, periodically request the session secret using the `clientCode` (`/auth/pluginSecret`) - we need to find a reasonable interval and limit obviously. This will only work once the user has logged in, and the API has confirmed their identity.
- We might want to add a "Log out" button that just removes the session secret (and maybe also makes a call to our server requesting for the session to be deleted - that should be able to reuse existing routes iirc).