### PR TITLE
Pad milliseconds with padStart instead of padEnd

### DIFF
--- a/app/lib/utils/time.ts
+++ b/app/lib/utils/time.ts
@@ -6,7 +6,7 @@ export const getRaceTimeStr = (raceTime: number): string => {
     return (
         `${`${minutes > 0 ? `${minutes}:` : ''}`
         + `${minutes > 0 ? String(seconds).padStart(2, '0') : seconds}`
-        + '.'}${String(milliseconds).padEnd(3, '0')}`
+        + '.'}${String(milliseconds).padStart(3, '0')}`
     );
 };
 


### PR DESCRIPTION
Milliseconds were formatted using `.padEnd` instead of `.padStart`.

Example of 34081ms:
Old: `34.810`
New: `38.081`