### PR TITLE
set drawers opened by default

### DIFF
--- a/app/components/maps/LoadedReplays.tsx
+++ b/app/components/maps/LoadedReplays.tsx
@@ -139,7 +139,7 @@ const LoadedReplay = ({
 const LoadedReplays = ({
     replays, timeLineGlobal,
 }: LoadedReplaysProps): JSX.Element => {
-    const [visible, setVisible] = useState(false);
+    const [visible, setVisible] = useState(true);
     const [followed, setFollowed] = useState<ReplayData>();
     const [hovered, setHovered] = useState<ReplayData>();
     const { numColorChange, cameraMode, setCameraMode } = useContext(SettingsContext);

--- a/app/components/maps/SidebarReplays.tsx
+++ b/app/components/maps/SidebarReplays.tsx
@@ -42,7 +42,7 @@ const SidebarReplays = ({
 
     const userProfileUrl = '/users/';
 
-    const [visible, setVisible] = useState(false);
+    const [visible, setVisible] = useState(true);
     const [visibleReplays, setVisibleReplays] = useState<FileResponse[]>([]);
 
     useEffect(() => {


### PR DESCRIPTION
When browsing map for the first time, SidebarReplays is opened by default
When loading 1st replay, LoadedReplays is opened by default