### PR TITLE
fix replay line colors not updating

### DIFF
--- a/app/components/maps/LoadedReplays.tsx
+++ b/app/components/maps/LoadedReplays.tsx
@@ -1,13 +1,13 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import {
-    CaretLeftOutlined, CaretRightOutlined, EyeOutlined, LeftCircleFilled,
+    CaretLeftOutlined, CaretRightOutlined, EyeOutlined,
 } from '@ant-design/icons';
 import {
-    Button, Checkbox, Drawer, Select, Row, Col, Slider, Radio, RadioChangeEvent, List, Divider,
+    Button, Drawer, Row, Col, Radio, RadioChangeEvent, List, Divider,
 } from 'antd';
 import React, {
-    Dispatch, SetStateAction, useContext, useState,
+    useContext, useState,
 } from 'react';
 import * as ReactColor from 'react-color';
 import * as THREE from 'three';
@@ -141,7 +141,7 @@ const LoadedReplays = ({
     const [visible, setVisible] = useState(true);
     const [followed, setFollowed] = useState<ReplayData>();
     const [hovered, setHovered] = useState<ReplayData>();
-    const { numColorChange, cameraMode, setCameraMode } = useContext(SettingsContext);
+    const { cameraMode, setCameraMode } = useContext(SettingsContext);
 
     const timeLineGlobal = GlobalTimeLineInfos.getInstance();
 

--- a/app/components/viewer/ReplayLines.tsx
+++ b/app/components/viewer/ReplayLines.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useContext, useMemo } from 'react';
 import * as THREE from 'three';
 import { ReplayData } from '../../lib/api/apiRequests';
 import {
@@ -35,8 +35,7 @@ const ReplayLine = ({
     replay, lineType, replayLineOpacity,
 }: ReplayLineProps) => {
     const points = useMemo(() => replay.samples.map((sample) => sample.position), [replay.samples]);
-
-    const colorBuffer = useMemo(() => lineType.colorsCallback(replay), [replay, lineType]);
+    const colorBuffer = useMemo(() => lineType.colorsCallback(replay), [replay, lineType, replay.color]);
 
     const onUpdate = useCallback(
         (self) => {


### PR DESCRIPTION
A context was removed from ReplayLines, resulting in the component no longer re rendering whenever a replay color was changed

The line colors useMemo now computes whenever it's replay.color changes