### PR TITLE
Fix replay upload freeze

### DIFF
--- a/plugin/Plugin_TMDojo.as
+++ b/plugin/Plugin_TMDojo.as
@@ -572,7 +572,7 @@ void PostRecordedData(ref @handle) {
                             "&endRaceTime=" + endRaceTime +
                             "&raceFinished=" + (finished ? "1" : "0");
         Net::HttpRequest@ req = Net::HttpPost(reqUrl, membuff.ReadToBase64(membuff.GetSize()), "application/octet-stream");
-        if (!req.Finished()) {
+        while (!req.Finished()) {
             yield();
         }
         UI::ShowNotification("TMDojo", "Uploaded replay successfully!");


### PR DESCRIPTION
There was a little stutter when plugin uploaded the replay data to the server
That stutter caused a lot of issues, especially on online / dedi servers