### PR TITLE
[Release] Better charts with multiple metrics, fix replay line colors, gas & brake number formatting, hide recording overlay when HUD is OFF, fix replay upload freeze

### DIFF
--- a/app/components/maps/LoadedReplays.tsx
+++ b/app/components/maps/LoadedReplays.tsx
@@ -1,13 +1,13 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import {
-    CaretLeftOutlined, CaretRightOutlined, EyeOutlined, LeftCircleFilled,
+    CaretLeftOutlined, CaretRightOutlined, EyeOutlined,
 } from '@ant-design/icons';
 import {
-    Button, Checkbox, Drawer, Select, Row, Col, Slider, Radio, RadioChangeEvent, List, Divider,
+    Button, Drawer, Row, Col, Radio, RadioChangeEvent, List, Divider,
 } from 'antd';
 import React, {
-    Dispatch, SetStateAction, useContext, useState,
+    useContext, useState,
 } from 'react';
 import * as ReactColor from 'react-color';
 import * as THREE from 'three';
@@ -141,7 +141,7 @@ const LoadedReplays = ({
     const [visible, setVisible] = useState(true);
     const [followed, setFollowed] = useState<ReplayData>();
     const [hovered, setHovered] = useState<ReplayData>();
-    const { numColorChange, cameraMode, setCameraMode } = useContext(SettingsContext);
+    const { cameraMode, setCameraMode } = useContext(SettingsContext);
 
     const timeLineGlobal = GlobalTimeLineInfos.getInstance();
 

--- a/app/components/viewer/ReplayLines.tsx
+++ b/app/components/viewer/ReplayLines.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useContext, useMemo } from 'react';
 import * as THREE from 'three';
 import { ReplayData } from '../../lib/api/apiRequests';
 import {
@@ -35,8 +35,7 @@ const ReplayLine = ({
     replay, lineType, replayLineOpacity,
 }: ReplayLineProps) => {
     const points = useMemo(() => replay.samples.map((sample) => sample.position), [replay.samples]);
-
-    const colorBuffer = useMemo(() => lineType.colorsCallback(replay), [replay, lineType]);
+    const colorBuffer = useMemo(() => lineType.colorsCallback(replay), [replay, lineType, replay.color]);
 
     const onUpdate = useCallback(
         (self) => {

--- a/app/components/viewer/ReplayLines.tsx
+++ b/app/components/viewer/ReplayLines.tsx
@@ -22,7 +22,7 @@ export const LineTypes: { [name: string]: LineType } = {
     speed: { name: 'Speed', colorsCallback: speedReplayColors },
     acceleration: { name: 'Acceleration', colorsCallback: accelerationReplayColors },
     gear: { name: 'Gear', colorsCallback: gearReplayColors },
-    rpm: { name: 'RPMs', colorsCallback: rpmReplayColors },
+    rpm: { name: 'RPM', colorsCallback: rpmReplayColors },
     inputs: { name: 'Inputs', colorsCallback: inputReplayColors },
 };
 

--- a/app/lib/charts/chartOptions.ts
+++ b/app/lib/charts/chartOptions.ts
@@ -134,17 +134,18 @@ export const inputSteerChartOptions = (): any => {
     return options;
 };
 
-export const rpmsAndGearChartOptions = (): any => {
+export const rpmAndGearChartOptions = (): any => {
     const options = chartOptionsTemplate();
     options.yAxis = [{
         ...options.yAxis,
         title: {
-            text: 'RPMs',
+            text: 'RPM',
         },
         labels: {
-            format: '{value} RPMs',
+            format: '{value} RPM',
         },
         lineWidth: 2,
+        height: '50%',
     }, {
         ...options.yAxis,
         title: {
@@ -154,7 +155,9 @@ export const rpmsAndGearChartOptions = (): any => {
             format: 'Gear {value}',
         },
         lineWidth: 2,
-        opposite: true,
+        offset: 0,
+        top: '50%',
+        height: '50%',
     }];
     return options;
 };
@@ -170,6 +173,7 @@ export const accelAndBrakeChartOptions = (): any => {
             format: 'Gaz {value}',
         },
         lineWidth: 2,
+        height: '50%',
     }, {
         ...options.yAxis,
         title: {
@@ -179,7 +183,9 @@ export const accelAndBrakeChartOptions = (): any => {
             format: 'Brake {value}',
         },
         lineWidth: 2,
-        opposite: true,
+        offset: 0,
+        top: '50%',
+        height: '50%',
     }];
     return options;
 };

--- a/app/lib/charts/chartTypes.ts
+++ b/app/lib/charts/chartTypes.ts
@@ -72,12 +72,12 @@ export const ChartTypes: { [name: string]: ChartType } = {
         name: 'RPM and Gears',
         chartData: [
             {
-                name: 'engineRpm',
-                dataCallback: (replayData: ReplayDataPoint) => replayData.engineRpm,
-            },
-            {
                 name: 'engineCurGear',
                 dataCallback: (replayData: ReplayDataPoint) => replayData.engineCurGear,
+            },
+            {
+                name: 'engineRpm',
+                dataCallback: (replayData: ReplayDataPoint) => replayData.engineRpm,
             },
         ],
         chartOptionsCallback: rpmsAndGearChartOptions,
@@ -86,12 +86,12 @@ export const ChartTypes: { [name: string]: ChartType } = {
         name: 'Gas and Brake inputs',
         chartData: [
             {
-                name: 'inputGasPedal',
-                dataCallback: (replayData: ReplayDataPoint) => replayData.inputGasPedal,
-            },
-            {
                 name: 'inputIsBraking',
                 dataCallback: (replayData: ReplayDataPoint) => replayData.inputIsBraking,
+            },
+            {
+                name: 'inputGasPedal',
+                dataCallback: (replayData: ReplayDataPoint) => replayData.inputGasPedal,
             },
         ],
         chartOptionsCallback: accelAndBrakeChartOptions,

--- a/app/lib/charts/chartTypes.ts
+++ b/app/lib/charts/chartTypes.ts
@@ -4,7 +4,7 @@ import {
     accelAndBrakeChartOptions,
     defaultChartOptions,
     inputSteerChartOptions,
-    rpmsAndGearChartOptions,
+    rpmAndGearChartOptions,
 } from './chartOptions';
 
 export interface ChartDataInfo {
@@ -80,7 +80,7 @@ export const ChartTypes: { [name: string]: ChartType } = {
                 dataCallback: (replayData: ReplayDataPoint) => replayData.engineRpm,
             },
         ],
-        chartOptionsCallback: rpmsAndGearChartOptions,
+        chartOptionsCallback: rpmAndGearChartOptions,
     },
     accelAndBrake: {
         name: 'Gas and Brake inputs',

--- a/app/lib/replays/replayData.ts
+++ b/app/lib/replays/replayData.ts
@@ -46,8 +46,8 @@ export class ReplayDataPoint {
         const gasAndBrake = this.readInt32(dataView);
         // gasAndBrake are encoded in a single byte using the first 2 bits
         //  00 = no input, 01 = gas, 10 = brake, 11 = gas+brake
-        this.inputGasPedal = (gasAndBrake & 1);
-        this.inputIsBraking = (gasAndBrake & 2);
+        this.inputGasPedal = (gasAndBrake & 1) ? 1 : 0;
+        this.inputIsBraking = (gasAndBrake & 2) ? 1 : 0;
         this.engineRpm = this.readFloat(dataView);
         this.engineCurGear = this.readInt32(dataView);
         this.up = this.readVector3(dataView);

--- a/app/lib/replays/replayLineColors.ts
+++ b/app/lib/replays/replayLineColors.ts
@@ -25,7 +25,7 @@ export const COLOR_MAP_GEARS: ColorMap = [
     { value: 7.0, color: { r: 0xff, g: 0xff, b: 0xff } },
 ];
 
-const COLOR_MAP_RPMS: ColorMap = [
+const COLOR_MAP_RPM: ColorMap = [
     { value: 10000.0, color: { r: 0xff, g: 0x00, b: 0 } },
     { value: 0.0, color: { r: 0x00, g: 0xff, b: 0 } },
 ];
@@ -62,7 +62,7 @@ export const rpmReplayColors = (replay: ReplayData): THREE.Float32BufferAttribut
     const colorBuffer = [];
     for (let i = 0; i < replay.samples.length; i++) {
         const sample = replay.samples[i];
-        const color = getColorFromMap(sample.engineRpm, COLOR_MAP_RPMS);
+        const color = getColorFromMap(sample.engineRpm, COLOR_MAP_RPM);
         colorBuffer.push(color.r, color.g, color.b);
     }
     return new THREE.Float32BufferAttribute(colorBuffer, 3);

--- a/plugin/Plugin_TMDojo.as
+++ b/plugin/Plugin_TMDojo.as
@@ -169,6 +169,7 @@ class TMDojo
 
     CTrackManiaNetwork@ network;
     int prevRaceTime = -6666;
+    int currentRaceTime = -6666;
 
     vec3 latestPlayerPosition;
     int numSamePositions = 0;
@@ -232,110 +233,7 @@ class TMDojo
         nvg::Text(textLeft, textTop, (recording ? "Recording" : "Not Recording"));
     }
 
-    void drawDebugBuffer(CSceneVehicleVis@ vis, CSmScriptPlayer@ sm_script, CGameCtnChallenge@ rootMap) {
-        int panelLeft = 180;
-        int panelTop = 50;
-
-        int panelWidth = 300;
-        int panelHeight = 540;
-
-        int topIncr = 18;
-
-        nvg::BeginPath();
-        nvg::Rect(panelLeft, panelTop, panelWidth, panelHeight);
-        nvg::FillColor(vec4(0,0,0,0.8));
-        nvg::Fill();
-        nvg::ClosePath();
-        vec4 colBorder = vec4(1, 1, 1, 1);
-        vec4 colBorderGreen = vec4(0.1, 1, 0.1, 1);
-        vec4 colBorderRed = vec4(1, 0.1, 0.1, 1);
-
-        int panelLeftCp = panelLeft + 8;
-        int panelTopCp = panelTop + 16;
-
-        nvg::BeginPath();
-        nvg::FontSize(12);
-        nvg::FillColor(vec4(1, 1, 1, 1));
-
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "CurrentRaceTime: " + sm_script.CurrentRaceTime);
-        panelTopCp += topIncr;
-
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "Position.x: " + vis.AsyncState.Position.x);
-        panelTopCp += topIncr;
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "Position.y: " + vis.AsyncState.Position.y);
-        panelTopCp += topIncr;
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "Position.z: " + vis.AsyncState.Position.z);
-        panelTopCp += topIncr;
-
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "WorldVel.x: " + vis.AsyncState.WorldVel.x);
-        panelTopCp += topIncr;
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "WorldVel.y: " + vis.AsyncState.WorldVel.y);
-        panelTopCp += topIncr;
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "WorldVel.z: " + vis.AsyncState.WorldVel.z);
-        panelTopCp += topIncr;
-
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "Speed: " + (vis.AsyncState.FrontSpeed * 3.6f));
-        panelTopCp += topIncr;
-
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "InputSteer: " + vis.AsyncState.InputSteer);
-        panelTopCp += topIncr;
-        
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "InputGasPedal: " + vis.AsyncState.InputGasPedal); 
-        panelTopCp += topIncr;
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "InputBrakePedal: " + vis.AsyncState.InputBrakePedal);
-        panelTopCp += topIncr;
-
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "EngineCurGear: " + vis.AsyncState.CurGear);
-        panelTopCp += topIncr;
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "EngineRpm: " + Vehicle::GetRPM(vis.AsyncState));
-        panelTopCp += topIncr;
-
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "Up.x: " + vis.AsyncState.Up.x);
-        panelTopCp += topIncr;
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "Up.y: " + vis.AsyncState.Up.y);
-        panelTopCp += topIncr;
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "Up.z: " + vis.AsyncState.Up.z);
-        panelTopCp += topIncr;
-
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "Dir.x: " + vis.AsyncState.Dir.x);
-        panelTopCp += topIncr;
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "Dir.y: " + vis.AsyncState.Dir.y);
-        panelTopCp += topIncr;
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "Dir.z: " + vis.AsyncState.Dir.z);
-        panelTopCp += topIncr;
-
-        // MISC
-        panelTopCp += topIncr;
-
-        //Draw::DrawString(vec2(panelLeftCp, panelTopCp), (g_dojo.serverAvailable ? colBorderGreen: colBorderRed) , "API: " + ApiUrl);
-        panelTopCp += topIncr;
-
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "recording: " + recording);
-        panelTopCp += topIncr;
-
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "playername: " + network.PlayerInfo.Name);
-        panelTopCp += topIncr;
-
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "playerlogin: " + network.PlayerInfo.Login);
-        panelTopCp += topIncr;
-
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "webid: " + network.PlayerInfo.WebServicesUserId);
-        panelTopCp += topIncr;
-
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "mapName: " + rootMap.MapInfo.NameForUi);
-        panelTopCp += topIncr;
-
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "mapUid: " + rootMap.MapInfo.MapUid);
-        panelTopCp += topIncr;
-
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "latestRecordedTime: " + latestRecordedTime);
-        panelTopCp += topIncr;
-
-        nvg::TextBox(panelLeftCp, panelTopCp, panelWidth, "size: " + membuff.GetSize() / 1024 + " kB");
-        panelTopCp += topIncr;
-    }
-
-    void FillBuffer(CSceneVehicleVis@ vis, CSmScriptPlayer@ sm_script, int currentRaceTime) {
+    void FillBuffer(CSceneVehicleVis@ vis, CSmScriptPlayer@ sm_script) {
         int gazAndBrake = 0;
         int gazPedal = vis.AsyncState.InputGasPedal > 0 ? 1 : 0;
         int isBraking = vis.AsyncState.InputBrakePedal > 0 ? 2 : 0;
@@ -343,7 +241,7 @@ class TMDojo
         gazAndBrake |= gazPedal;
         gazAndBrake |= isBraking;
 
-        membuff.Write(currentRaceTime);
+        membuff.Write(g_dojo.currentRaceTime);
 
         membuff.Write(vis.AsyncState.Position.x);
         membuff.Write(vis.AsyncState.Position.y);
@@ -391,7 +289,6 @@ class TMDojo
         membuff.Write(vis.AsyncState.RRSlipCoef);
         membuff.Write(vis.AsyncState.RRDamperLen);
     }
-    
 
 	void Render()
 	{
@@ -414,13 +311,12 @@ class TMDojo
             return;
         }
 
-		CSceneVehicleVis@ vis = null;
+        CSceneVehicleVis@ vis = null;
 
 		auto player = GetViewingPlayer();
 		if (player !is null && player.User.Name.Contains(network.PlayerInfo.Name)) {
 			@vis = Vehicle::GetVis(sceneVis, player);
 		}
-
 
 		if (vis is null) {
 			return;
@@ -440,18 +336,29 @@ class TMDojo
         }
 
         auto playgroundScript = cast<CSmArenaRulesMode>(app.PlaygroundScript);
-        int currentRaceTime = sm_script.CurrentRaceTime;
 
         if (app.CurrentPlayground !is null && app.CurrentPlayground.Interface !is null) {
             if (Dev::GetOffsetUint32(app.CurrentPlayground.Interface, 0x1C) == 0) {
-                currentRaceTime = playgroundScript.Now - player.ScriptAPI.StartTime;
+
+                if (playgroundScript == null) {
+                    if (app.Network.PlaygroundClientScriptAPI != null) {
+                        auto playgroundClientScriptAPI = cast<CGamePlaygroundClientScriptAPI>(app.Network.PlaygroundClientScriptAPI);
+                        if (playgroundClientScriptAPI != null) {
+                            g_dojo.currentRaceTime = playgroundClientScriptAPI.GameTime - player.ScriptAPI.StartTime;
+                        }
+                    }
+                } else {
+                    g_dojo.currentRaceTime = playgroundScript.Now - player.ScriptAPI.StartTime;
+                }
+            } else {
+                g_dojo.currentRaceTime = sm_script.CurrentRaceTime;
             }
         }
 
-        if (!recording && currentRaceTime > -50 && currentRaceTime < 0) {
+        if (!recording && g_dojo.currentRaceTime > -50 && g_dojo.currentRaceTime < 0) {
             recording = true;
         }
-        
+
         if (recording) {
             
             if (uiConfig.UISequence == 11) {
@@ -489,7 +396,7 @@ class TMDojo
                 }
 
                 startnew(PostRecordedData, fh);
-            } else if (latestRecordedTime > 0 && currentRaceTime < 0) {
+            } else if (latestRecordedTime > 0 && g_dojo.currentRaceTime < 0) {
                 // Give up
                 print("[TMDojo]: Give up");
 
@@ -503,7 +410,7 @@ class TMDojo
                 startnew(PostRecordedData, fh);
             } else {
                  // Record current data
-                int timeSinceLastRecord = currentRaceTime - latestRecordedTime;
+                int timeSinceLastRecord = g_dojo.currentRaceTime - latestRecordedTime;
                 if (timeSinceLastRecord > (1.0 / RECORDING_FPS) * 1000) {
                     // Keep track of the amount of samples for which the position did not changed, used to pause recording
                     if (Math::Abs(latestPlayerPosition.x - sm_script.Position.x) < 0.001 &&
@@ -515,16 +422,13 @@ class TMDojo
                     }
                     // Fill buffer if player has moved recently
                     if (numSamePositions < RECORDING_FPS) {
-                        FillBuffer(vis, sm_script, currentRaceTime);
-                        latestRecordedTime = currentRaceTime;
+                        FillBuffer(vis, sm_script);
+                        latestRecordedTime = g_dojo.currentRaceTime;
                     }
 
                     latestPlayerPosition = sm_script.Position;
                 }
             }
-        }
-        if (DebugOverlayEnabled) {
-            drawDebugBuffer(vis, sm_script, rootMap);
         }
 	}
 }
@@ -550,6 +454,7 @@ void PostRecordedData(ref @handle) {
         print("[TMDojo]: Not saving file, too little data");
         membuff.Resize(0);
         latestRecordedTime = -6666;
+        g_dojo.currentRaceTime = -6666;
         recording = false;
         return;
     }
@@ -574,6 +479,7 @@ void PostRecordedData(ref @handle) {
     }
     recording = false;
     latestRecordedTime = -6666;
+    g_dojo.currentRaceTime = -6666;
     membuff.Resize(0);
 }
 
@@ -740,12 +646,8 @@ void Render() {
 	}
 }
 
-void RenderInterface() {
-    if (!authWindowOpened) {
-        return;
-    }
+void renderAuthWindow() {
     UI::SetNextWindowContentSize(780, 230);
-
     UI::Begin("TMDojo Plugin Authentication", authWindowOpened);
     if (!pluginAuthed) {
         UI::Text(orange + "Not authenticated");
@@ -774,4 +676,89 @@ void RenderInterface() {
         }
     }
     UI::End();
+}
+
+void renderDebugOverlay() {
+    UI::SetNextWindowContentSize(780, 230);
+    UI::Begin("TMDojo Debug", DebugOverlayEnabled);
+
+
+    UI::Columns(2);
+
+    UI::Text("Recording: " + recording);
+    UI::Text("CurrentRaceTime: " + g_dojo.currentRaceTime);
+    UI::Text("LatestRecordedTime: " + latestRecordedTime);
+    UI::Text("Buffer Size (bytes): " + membuff.GetSize());
+
+    CSceneVehicleVis@ vis = null;
+
+    auto app = GetApp();
+
+    auto sceneVis = app.GameScene;
+    if (sceneVis != null && app.Editor == null) {
+        if (app.CurrentPlayground != null && app.CurrentPlayground.GameTerminals.get_Length() > 0 && app.CurrentPlayground.GameTerminals[0].GUIPlayer != null) {
+            auto player = g_dojo.GetViewingPlayer();
+            if (player !is null && player.User.Name.Contains(g_dojo.network.PlayerInfo.Name)) {
+                @vis = Vehicle::GetVis(sceneVis, player);
+            }
+        }
+    }
+
+    if (vis != null) {
+        UI::NextColumn();
+
+        UI::Text("Position.x: " + vis.AsyncState.Position.x);
+        UI::Text("Position.y: " + vis.AsyncState.Position.y);
+        UI::Text("Position.z: " + vis.AsyncState.Position.z);
+
+        UI::Text("WorldVel.x: " + vis.AsyncState.WorldVel.x);
+        UI::Text("WorldVel.y: " + vis.AsyncState.WorldVel.y);
+        UI::Text("WorldVel.z: " + vis.AsyncState.WorldVel.z);
+
+        UI::Text("Speed: " + (vis.AsyncState.FrontSpeed * 3.6f));
+
+        UI::Text("InputSteer: " + vis.AsyncState.InputSteer);
+
+        UI::Text("WheelAngle: " + vis.AsyncState.FLSteerAngle);
+        
+        UI::Text("InputGasPedal: " + vis.AsyncState.InputGasPedal); 
+        UI::Text("InputBrakePedal: " + vis.AsyncState.InputBrakePedal);
+
+        UI::Text("EngineCurGear: " + vis.AsyncState.CurGear);
+        UI::Text("EngineRpm: " + Vehicle::GetRPM(vis.AsyncState));
+
+        UI::Text("Up.x: " + vis.AsyncState.Up.x);
+        UI::Text("Up.y: " + vis.AsyncState.Up.y);
+        UI::Text("Up.z: " + vis.AsyncState.Up.z);
+
+        UI::Text("Dir.x: " + vis.AsyncState.Dir.x);
+        UI::Text("Dir.y: " + vis.AsyncState.Dir.y);
+        UI::Text("Dir.z: " + vis.AsyncState.Dir.z);
+
+        UI::Text("FLGroundContactMaterial: " + vis.AsyncState.FLGroundContactMaterial);
+        UI::Text("FRGroundContactMaterial: " + vis.AsyncState.FRGroundContactMaterial);
+        UI::Text("RLGroundContactMaterial: " + vis.AsyncState.RLGroundContactMaterial);
+        UI::Text("RRGroundContactMaterial: " + vis.AsyncState.RRGroundContactMaterial);
+        
+        UI::Text("FLSlipCoef: " + vis.AsyncState.FLSlipCoef);
+        UI::Text("FRSlipCoef: " + vis.AsyncState.FRSlipCoef);
+        UI::Text("RLSlipCoef: " + vis.AsyncState.RLSlipCoef);
+        UI::Text("RRSlipCoef: " + vis.AsyncState.RRSlipCoef);
+
+        UI::Text("FLDamperLen: " + vis.AsyncState.FLDamperLen);
+        UI::Text("FRDamperLen: " + vis.AsyncState.FRDamperLen);
+        UI::Text("RLDamperLen: " + vis.AsyncState.RLDamperLen);
+        UI::Text("RRDamperLen: " + vis.AsyncState.RRDamperLen);
+    }
+
+    UI::End();
+}
+
+void RenderInterface() {
+    if (authWindowOpened) {
+        renderAuthWindow();
+    }
+    if (DebugOverlayEnabled) {
+        renderDebugOverlay();
+    }
 }

--- a/plugin/Plugin_TMDojo.as
+++ b/plugin/Plugin_TMDojo.as
@@ -476,7 +476,7 @@ void PostRecordedData(ref @handle) {
                             "&endRaceTime=" + endRaceTime +
                             "&raceFinished=" + (finished ? "1" : "0");
         Net::HttpRequest@ req = Net::HttpPost(reqUrl, membuff.ReadToBase64(membuff.GetSize()), "application/octet-stream");
-        if (!req.Finished()) {
+        while (!req.Finished()) {
             yield();
         }
         UI::ShowNotification("TMDojo", "Uploaded replay successfully!");

--- a/plugin/Plugin_TMDojo.as
+++ b/plugin/Plugin_TMDojo.as
@@ -337,6 +337,8 @@ class TMDojo
 
         bool hudOff = false;
 
+        bool hudOff = false;
+
         if (app.CurrentPlayground !is null && app.CurrentPlayground.Interface !is null) {
             if (Dev::GetOffsetUint32(app.CurrentPlayground.Interface, 0x1C) == 0) {
                 hudOff = true;

--- a/plugin/Plugin_TMDojo.as
+++ b/plugin/Plugin_TMDojo.as
@@ -331,15 +331,15 @@ class TMDojo
             return;
         }
 
-        if (Enabled && OverlayEnabled) {
-            this.drawOverlay();
-        }
+        
 
         auto playgroundScript = cast<CSmArenaRulesMode>(app.PlaygroundScript);
 
+        bool hudOff = false;
+
         if (app.CurrentPlayground !is null && app.CurrentPlayground.Interface !is null) {
             if (Dev::GetOffsetUint32(app.CurrentPlayground.Interface, 0x1C) == 0) {
-
+                hudOff = true;
                 if (playgroundScript == null) {
                     if (app.Network.PlaygroundClientScriptAPI != null) {
                         auto playgroundClientScriptAPI = cast<CGamePlaygroundClientScriptAPI>(app.Network.PlaygroundClientScriptAPI);
@@ -353,6 +353,10 @@ class TMDojo
             } else {
                 g_dojo.currentRaceTime = sm_script.CurrentRaceTime;
             }
+        }
+
+        if (Enabled && OverlayEnabled && !hudOff) {     
+            this.drawOverlay();
         }
 
         if (!recording && g_dojo.currentRaceTime > -50 && g_dojo.currentRaceTime < 0) {


### PR DESCRIPTION
### Summary

Website:
- Replay charts with multiple metrics are splitted to prevent lines overlapping
- Updating the color of a replay updates the color of it's line
- Gas & Brake values back to 1 or 0

Plugin:
- Recording indicator is no longer on screen when in game HUD is turned OFF
- New method to get in game timer in online mode fixes HUD OFF issues
- Asynchronous replay upload removed the stutter when finishing a track

### All PRs:
- #91 
- #93 
- #94 
- #90 
- #92 