### PR TITLE
Add plugin auth requirement for replay submission

### DIFF
--- a/plugin/Plugin_TMDojo.as
+++ b/plugin/Plugin_TMDojo.as
@@ -473,10 +473,20 @@ void PostRecordedData(ref @handle) {
                             "&webId=" + network.PlayerInfo.WebServicesUserId +
                             "&endRaceTime=" + endRaceTime +
                             "&raceFinished=" + (finished ? "1" : "0");
-        Net::HttpRequest@ req = Net::HttpPost(reqUrl, membuff.ReadToBase64(membuff.GetSize()), "application/octet-stream");
+        // build up request instance
+        Net::HttpRequest req;
+        req.Method = Net::HttpMethod::Post;
+        req.Url = reqUrl;
+        req.Body = membuff.ReadToBase64(membuff.GetSize());
+        dictionary@ Headers = dictionary();
+        Headers["Authorization"] = "dojo " + SessionId;
+        Headers["Content-Type"] = "application/octet-stream";
+        @req.Headers = Headers;
+        req.Start();
         while (!req.Finished()) {
             yield();
         }
+        // TODO: handle upload errors
         UI::ShowNotification("TMDojo", "Uploaded replay successfully!");
     }
     recording = false;

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -8,12 +8,18 @@ import { getUserBySessionId } from '../lib/db';
  * Sets req.user to undefined if no user is logged in
  */
 const authMiddleware = async (req: Request, res: Response, next: Function) => {
-    const { sessionId } = req.cookies;
+    let { sessionId } = req.cookies;
 
-    // Check for missing parameters
     if (sessionId === undefined || typeof sessionId !== 'string') {
-        req.user = undefined;
-        return next();
+        // check for Auth header (used by plugin) - format is "dojo <sessionId>"
+        const authHeader = req.headers.authorization;
+        if (authHeader && authHeader.startsWith('dojo ')) {
+            [, sessionId] = authHeader.split(' ');
+        } else {
+            // no sessionId and no auth header, so no user
+            req.user = undefined;
+            return next();
+        }
     }
 
     // Get user by session secret

--- a/server/src/routes/replays.ts
+++ b/server/src/routes/replays.ts
@@ -85,6 +85,16 @@ router.get('/:replayId', async (req: Request, res: Response, next: Function) => 
  */
 // eslint-disable-next-line consistent-return
 router.post('/', (req: Request, res: Response, next: Function): any => {
+    if (
+        !req.user
+        || req.user.playerName !== req.query.playerName
+        || req.user.webId !== req.query.webId
+        || req.user.playerLogin !== req.query.playerLogin
+    ) {
+        // reject replay uploads by unauthenticated users
+        return res.status(401).send('Authentication required to submit replay.');
+    }
+
     const paramNames = [
         'authorName', 'mapName', 'mapUId', 'endRaceTime', 'raceFinished', 'playerName', 'playerLogin', 'webId',
     ];
@@ -97,7 +107,7 @@ router.post('/', (req: Request, res: Response, next: Function): any => {
         }
     });
     if (!requestValid) {
-        return res.status(400).send({ message: 'Request is missing one or more parameters' });
+        return res.status(400).send('Request is missing one or more parameters');
     }
 
     const secureMapName = decodeURIComponent(req.query.mapName as string);
@@ -165,7 +175,7 @@ router.delete('/:replayId', async (req, res) => {
     // Check user
     const { user } = req;
     if (user === undefined || user.webId !== replayUser.webId) {
-        res.status(401).send('Not authorized to delete replay.');
+        res.status(401).send('Authentication required to delete replay.');
         return;
     }
 


### PR DESCRIPTION
- Added server handling for `Authorization` header auth (as opposed to cookie)
- Added logic to refuse replay submissions without auth
- Restructure replay submission request in the plugin to set header

TODO:
- Proper error handling for plugin requests (bit out of scope of this PR though)