### PR TITLE
Map Stats

### DIFF
--- a/app/components/common/PlayerLink.tsx
+++ b/app/components/common/PlayerLink.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+import React from 'react';
+
+const ABSOLUTE_USERS_PATH = '/users';
+
+interface PlayerLinkProps {
+    webId: string;
+    name: string;
+    className?: string;
+    style?: React.CSSProperties
+}
+const PlayerLink = ({
+    webId, name, className, style,
+}: PlayerLinkProps) => (
+    <Link href={`${ABSOLUTE_USERS_PATH}/${webId}`}>
+        <a
+            target="_blank"
+            rel="noreferrer"
+            href={`${ABSOLUTE_USERS_PATH}/${webId}`}
+            className={className}
+            style={style}
+        >
+            {name}
+        </a>
+    </Link>
+);
+
+export default PlayerLink;

--- a/app/components/mapStats/AggregateMapStats.tsx
+++ b/app/components/mapStats/AggregateMapStats.tsx
@@ -1,0 +1,24 @@
+import { Col, Row, Statistic } from 'antd';
+import React from 'react';
+import { FileResponse } from '../../lib/api/apiRequests';
+import { msToTime } from '../../lib/utils/time';
+
+interface AggregateMapStatsProps {
+    replays: FileResponse[];
+}
+const AggregateMapStats = ({ replays }: AggregateMapStatsProps) => {
+    const totalRecordedTime = replays.reduce((a, b) => a + b.endRaceTime, 0);
+
+    return (
+        <Row gutter={16}>
+            <Col span={12}>
+                <Statistic title="Amount" value={replays ? replays.length : 0} />
+            </Col>
+            <Col span={12}>
+                <Statistic title="Total Time" value={msToTime(totalRecordedTime)} />
+            </Col>
+        </Row>
+    );
+};
+
+export default AggregateMapStats;

--- a/app/components/mapStats/FastestTimeProgression.tsx
+++ b/app/components/mapStats/FastestTimeProgression.tsx
@@ -1,0 +1,130 @@
+import React, { useMemo } from 'react';
+import Highcharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+import { getRaceTimeStr } from '../../lib/utils/time';
+import { FileResponse } from '../../lib/api/apiRequests';
+
+interface FastestTimeProgressionProps {
+    replays: FileResponse[];
+}
+const FastestTimeProgression = ({ replays } : FastestTimeProgressionProps) => {
+    const calculateFastestTimeProgressions = (): FileResponse[] => {
+        const fastestTimeProgressions: FileResponse[] = [];
+        const sortedReplays = replays.sort((a, b) => a.date - b.date);
+
+        fastestTimeProgressions.push(sortedReplays[0]);
+        for (let i = 1; i < sortedReplays.length; i++) {
+            const currentReplay = sortedReplays[i];
+            const latestFastestReplay = fastestTimeProgressions[fastestTimeProgressions.length - 1];
+            if (currentReplay.raceFinished
+                && currentReplay.endRaceTime < latestFastestReplay.endRaceTime) {
+                fastestTimeProgressions.push(currentReplay);
+            }
+        }
+        return fastestTimeProgressions;
+    };
+
+    interface ChartDataPoint {
+        x: number;
+        y: number;
+    }
+
+    const data: ChartDataPoint[] = useMemo(
+        () => calculateFastestTimeProgressions().map((replay) => ({
+            x: replay.date,
+            y: replay.endRaceTime,
+            player: replay.playerName,
+        })),
+        [replays],
+    );
+
+    const columnOptions = {
+        credits: {
+            enabled: false,
+        },
+        chart: {
+            type: 'line',
+            backgroundColor: 'transparent',
+            style: {
+                color: 'white',
+            },
+            zoomType: 'x',
+        },
+        title: {
+            text: '',
+        },
+        subtitle: {
+            text: '',
+        },
+        xAxis: {
+            type: 'datetime',
+            crosshair: true,
+            labels: {
+                style: {
+                    color: 'white',
+                },
+            },
+        },
+        yAxis: {
+            title: {
+                text: '',
+            },
+            labels: {
+                style: {
+                    color: 'white',
+                },
+                formatter: function yAxisLabelFormatter(this: any) {
+                    // eslint-disable-next-line react/no-this-in-sfc
+                    return getRaceTimeStr(this.value);
+                },
+            },
+            gridLineColor: '#333',
+        },
+        legend: {
+            itemStyle: {
+                color: 'white',
+            },
+        },
+        tooltip: {
+            headerFormat: '<span style="font-size:12px">{point.key}</span><table>',
+            pointFormat: '<tr>'
+            + '<td style="color:{series.color};padding:0"><b>{series.name}: </b></td>'
+            + '<td style="padding:0"><b>{point.y}ms</b></td></tr>'
+            + '<tr>'
+            + '<td style="color:{series.color};padding:0"><b>Player: </b></td>'
+            + '<td style="padding:0"><b>{point.player}ms</b></td></tr>',
+            footerFormat: '</table>',
+            shared: true,
+            useHTML: true,
+        },
+        plotOptions: {
+            line: {
+                dataLabels: {
+                    enabled: true,
+                    formatter: function dataLabelFormatter(this: any) {
+                        // eslint-disable-next-line react/no-this-in-sfc
+                        return `[${this.point.player}] ${getRaceTimeStr(this.y)}`;
+                    },
+                    color: 'white',
+                    shadow: false,
+                    allowOverlap: true,
+                },
+            },
+        },
+        series: [{
+            name: 'Time',
+            data,
+            step: 'left',
+        }],
+    };
+
+    return (
+
+        <HighchartsReact
+            highcharts={Highcharts}
+            options={columnOptions}
+        />
+    );
+};
+
+export default FastestTimeProgression;

--- a/app/components/mapStats/FastestTimeProgression.tsx
+++ b/app/components/mapStats/FastestTimeProgression.tsx
@@ -4,6 +4,7 @@ import HighchartsReact from 'highcharts-react-official';
 import Link from 'next/link';
 import { getRaceTimeStr, timeDifference } from '../../lib/utils/time';
 import { FileResponse } from '../../lib/api/apiRequests';
+import PlayerLink from '../common/PlayerLink';
 
 interface FastestTimeProgressionProps {
     replays: FileResponse[];
@@ -151,18 +152,6 @@ const FastestTimeProgression = ({ replays } : FastestTimeProgressionProps) => {
 
     const fastestTime = timeProgressionData[timeProgressionData.length - 1];
 
-    // TODO: extract to common PlayerLink component
-    interface PlayerLinkProps {
-        webId: string; name: string
-    }
-    const PlayerLink = ({ webId, name }: PlayerLinkProps) => (
-        <Link href={`/users/${webId}`}>
-            <a target="_blank" rel="noreferrer" href={`/users/${webId}`}>
-                {name}
-            </a>
-        </Link>
-    );
-
     return (
         <>
             <div className="flex flex-col items-center w-full mb-6">
@@ -172,7 +161,8 @@ const FastestTimeProgression = ({ replays } : FastestTimeProgressionProps) => {
                 </div>
                 <div><b>Fastest Time</b></div>
                 <div className="text-xl mb-1">
-                    {`${getRaceTimeStr(fastestTime.replay.endRaceTime)} by `}
+                    {getRaceTimeStr(fastestTime.replay.endRaceTime)}
+                    {' by '}
                     <PlayerLink webId={fastestTime.replay.webId} name={fastestTime.replay.playerName} />
                 </div>
                 <div className="text-xs">{timeDifference(new Date().getTime(), fastestTime.replay.date)}</div>

--- a/app/components/mapStats/FastestTimeProgression.tsx
+++ b/app/components/mapStats/FastestTimeProgression.tsx
@@ -1,7 +1,10 @@
+// Disable this rule for highchart callback functions
+/* eslint-disable react/no-this-in-sfc */
+
 import React, { useMemo } from 'react';
 import Highcharts, { some } from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
-import Link from 'next/link';
+import dayjs from 'dayjs';
 import { getRaceTimeStr, timeDifference } from '../../lib/utils/time';
 import { FileResponse } from '../../lib/api/apiRequests';
 import PlayerLink from '../common/PlayerLink';
@@ -52,7 +55,7 @@ const FastestTimeProgression = ({ replays } : FastestTimeProgressionProps) => {
         [replays, timeProgressionData],
     );
 
-    const columnOptions = {
+    const options = {
         credits: {
             enabled: false,
         },
@@ -109,17 +112,25 @@ const FastestTimeProgression = ({ replays } : FastestTimeProgressionProps) => {
                 color: 'lightgray',
             },
         },
-        // TODO: create better tooltip with correct date and time formatting
         tooltip: {
-            headerFormat: '<span style="font-size:12px">Date: {point.key}</span><table>',
-            pointFormat: '<tr>'
-            + '<td style="color:{series.color};padding:0"><b>Time:</b></td>'
-            + '<td style="padding:0 4px"><b>{point.y}ms</b></td></tr>'
-            + '<tr>'
-            + '<td style="color:{series.color};padding:0"><b>Player:</b></td>'
-            + '<td style="padding:0 4px"><b>{point.replay.playerName}</b></td></tr>',
-            footerFormat: '</table>',
-            shared: true,
+            // Highchart only accepts string tooltips, that's why this returns a HTML string
+            formatter: function tooltipFormatter(this: any) {
+                return `
+                    <span style="font-size: 10px">
+                        ${dayjs(this.key).format('MMM D YYYY, HH:MM:ss')}
+                    </span>
+                    </br>
+                    <span style="font-size: 13px">
+                        ${timeDifference(new Date().getTime(), this.point.replay.date)}
+                    </span>
+                    </br>
+                    <span style="font-size: 13px">
+                        <b>${getRaceTimeStr(this.point.replay.endRaceTime)}</b>
+                        ${' by '}
+                        <b>${this.point.replay.playerName}</b>
+                    </span>
+                `;
+            },
             useHTML: true,
         },
         plotOptions: {
@@ -169,7 +180,7 @@ const FastestTimeProgression = ({ replays } : FastestTimeProgressionProps) => {
             </div>
             <HighchartsReact
                 highcharts={Highcharts}
-                options={columnOptions}
+                options={options}
             />
         </>
     );

--- a/app/components/mapStats/FastestTimeProgression.tsx
+++ b/app/components/mapStats/FastestTimeProgression.tsx
@@ -140,7 +140,6 @@ const FastestTimeProgression = ({ replays } : FastestTimeProgressionProps) => {
             name: 'Other Times',
             data: allDataPoints,
             color: 'gray',
-            visible: false,
         }],
     };
 

--- a/app/components/mapStats/ReplayTimesHistogram.tsx
+++ b/app/components/mapStats/ReplayTimesHistogram.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import Highcharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+import bellcurve from 'highcharts/modules/histogram-bellcurve';
+import { getRaceTimeStr } from '../../lib/utils/time';
+import { FileResponse } from '../../lib/api/apiRequests';
+
+if (typeof Highcharts === 'object') {
+    bellcurve(Highcharts);
+}
+
+interface ReplayTimesHistogramProps {
+    replays: FileResponse[];
+    binSize: number;
+}
+const ReplayTimesHistogram = ({ replays, binSize } : ReplayTimesHistogramProps) => {
+    const histogramBuckets = {} as { [key: number]: number };
+
+    replays.forEach((replay) => {
+        const bucket = Math.floor(replay.endRaceTime / binSize) * binSize;
+        if (histogramBuckets[bucket] === undefined) {
+            histogramBuckets[bucket] = 0;
+        }
+        histogramBuckets[bucket] += 1;
+    });
+
+    const histogramKeys = Object.keys(histogramBuckets).sort();
+    const min = Math.min(...histogramKeys.map((key) => parseInt(key, 10)));
+    const max = Math.max(...histogramKeys.map((key) => parseInt(key, 10)));
+
+    const axisValues: number[] = [];
+    for (let val = min; val <= max; val += binSize) {
+        axisValues.push(val);
+    }
+    const histogramData = axisValues.map((key) => histogramBuckets[key] || 0);
+
+    const columnOptions = {
+        credits: {
+            enabled: false,
+        },
+        chart: {
+            type: 'column',
+            backgroundColor: 'transparent',
+            style: {
+                color: 'white',
+            },
+        },
+        title: {
+            text: '',
+        },
+        subtitle: {
+            text: '',
+        },
+        xAxis: {
+            categories: axisValues.map((value) => `${getRaceTimeStr(value)}`),
+            crosshair: true,
+            labels: {
+                style: {
+                    color: 'white',
+                },
+            },
+        },
+        yAxis: {
+            min: 0,
+            title: {
+                text: '',
+            },
+            labels: {
+                style: {
+                    color: 'white',
+                },
+            },
+            gridLineColor: '#333',
+        },
+        legend: {
+            itemStyle: {
+                color: 'white',
+            },
+        },
+        tooltip: {
+            headerFormat: '<span style="font-size:10px">{point.key}</span><table>',
+            pointFormat: '<tr><td style="color:{series.color};padding:0">{series.name}: </td>'
+            + '<td style="padding:0"><b>{point.y:.1f} replays</b></td></tr>',
+            footerFormat: '</table>',
+            shared: true,
+            useHTML: true,
+        },
+        plotOptions: {
+            column: {
+                pointPadding: 0,
+                borderWidth: 0,
+                groupPadding: 0,
+                shadow: false,
+            },
+        },
+        series: [{
+            name: 'Finish Times',
+            data: histogramData,
+
+        }],
+    };
+
+    return (
+
+        <HighchartsReact
+            highcharts={Highcharts}
+            options={columnOptions}
+        />
+    );
+};
+
+export default ReplayTimesHistogram;

--- a/app/components/maps/MapHeader.tsx
+++ b/app/components/maps/MapHeader.tsx
@@ -9,9 +9,10 @@ import UserDisplay from '../common/UserDisplay';
 
 interface Props {
     mapInfo: MapInfo;
+    title: string;
 }
 
-const MapHeader = ({ mapInfo }: Props): JSX.Element => {
+const MapHeader = ({ mapInfo, title }: Props): JSX.Element => {
     const router = useRouter();
 
     const hasExchangeId = mapInfo.exchangeid !== undefined && mapInfo.exchangeid !== 0;
@@ -23,7 +24,7 @@ const MapHeader = ({ mapInfo }: Props): JSX.Element => {
     return (
         <PageHeader
             onBack={() => router.push('/')}
-            title="Replay viewer"
+            title={title}
             subTitle={(
                 <div className="flex flex-row gap-4 items-baseline">
                     {cleanTMFormatting(mapInfo.name || '')}

--- a/app/components/maps/SidebarReplays.tsx
+++ b/app/components/maps/SidebarReplays.tsx
@@ -13,6 +13,7 @@ import { deleteReplay, FileResponse } from '../../lib/api/apiRequests';
 import { getRaceTimeStr, timeDifference } from '../../lib/utils/time';
 import { AuthContext } from '../../lib/contexts/AuthContext';
 import SideDrawerExpandButton from '../common/SideDrawerExpandButton';
+import PlayerLink from '../common/PlayerLink';
 
 interface ExtendedFileResponse extends FileResponse {
     readableTime: string;
@@ -89,12 +90,8 @@ const SidebarReplays = ({
             dataIndex: 'playerName',
             filters: getUniqueFilters((replay) => replay.playerName),
             onFilter: (value, record) => record.playerName === value,
-            render: (text, replay) => (
-                <Link href={`${userProfileUrl}${replay.webId}`}>
-                    <a target="_blank" rel="noreferrer" href={`${userProfileUrl}${replay.webId}`}>
-                        {replay.playerName}
-                    </a>
-                </Link>
+            render: (_, replay) => (
+                <PlayerLink webId={replay.webId} name={replay.playerName} />
             ),
         },
         {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -17,6 +17,7 @@
         "@types/three": "^0.127.1",
         "antd": "^4.15.2",
         "axios": "^0.21.1",
+        "dayjs": "^1.10.7",
         "highcharts": "^9.1.1",
         "highcharts-react-official": "^3.0.0",
         "next": "^10.0.9",
@@ -4849,6 +4850,11 @@
       "engines": {
         "node": ">=0.11"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
     },
     "node_modules/debounce": {
       "version": "1.2.1",
@@ -14116,6 +14122,11 @@
       "version": "2.21.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.1.tgz",
       "integrity": "sha512-m1WR0xGiC6j6jNFAyW4Nvh4WxAi4JF4w9jRJwSI8nBmNcyZXPcP9VUQG+6gHQXAmqaGEKDKhOqAtENDC941UkA=="
+    },
+    "dayjs": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
     },
     "debounce": {
       "version": "1.2.1",

--- a/app/package.json
+++ b/app/package.json
@@ -19,6 +19,7 @@
     "@types/three": "^0.127.1",
     "antd": "^4.15.2",
     "axios": "^0.21.1",
+    "dayjs": "^1.10.7",
     "highcharts": "^9.1.1",
     "highcharts-react-official": "^3.0.0",
     "next": "^10.0.9",

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -54,11 +54,13 @@ const Home = (): JSX.Element => {
             render: (_, map) => {
                 const statsRef = `/maps/${map.mapUId}/stats`;
                 return (
-                    <Button href={statsRef} size="small" className="flex items-center">
-                        <PieChartOutlined />
-                        {' '}
-                        Stats
-                    </Button>
+                    <div className="flex gap-2 pr-2">
+                        <Button href={statsRef} size="small" className="flex items-center">
+                            <PieChartOutlined />
+                            {' '}
+                            Stats
+                        </Button>
+                    </div>
                 );
             },
             width: 0,

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -5,7 +5,7 @@ import {
 } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 
-import { ReloadOutlined } from '@ant-design/icons';
+import { PieChartOutlined, ReloadOutlined } from '@ant-design/icons';
 import { AvailableMap, getAvailableMaps } from '../lib/api/apiRequests';
 import InfoCard from '../components/landing/InfoCard';
 import { timeDifference } from '../lib/utils/time';
@@ -48,6 +48,20 @@ const Home = (): JSX.Element => {
             },
             sorter: (a, b) => a.mapName.localeCompare(b.mapName),
             width: '65%',
+        },
+        {
+            title: '',
+            render: (_, map) => {
+                const statsRef = `/maps/${map.mapUId}/stats`;
+                return (
+                    <Button href={statsRef} size="small" className="flex items-center">
+                        <PieChartOutlined />
+                        {' '}
+                        Stats
+                    </Button>
+                );
+            },
+            width: 0,
         },
         {
             title: 'Last updated',
@@ -97,7 +111,6 @@ const Home = (): JSX.Element => {
                             size="small"
                             showSorterTooltip={false}
                             pagination={{ defaultPageSize: 10, hideOnSinglePage: true }}
-                            bordered
                         />
                     </Spin>
                 </Card>

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import {
-    Layout, Input, Table, Tooltip, Button, Card, Spin,
+    Input, Table, Tooltip, Button, Card, Spin,
 } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -83,39 +83,41 @@ const Home = (): JSX.Element => {
     ];
 
     return (
-        <Layout>
-            <Layout.Content className="w-3/5 m-auto h-full flex flex-col pt-8">
+        <div className="flex flex-col items-center min-h-screen" style={{ backgroundColor: '#1F1F1F' }}>
+            <div className="flex flex-col gap-6 w-3/5 h-full py-6">
                 <InfoCard />
-                <Card className="mt-8">
-                    <Spin spinning={loadingReplays}>
+                <div className="w-full">
+                    <Card>
+                        <Spin spinning={loadingReplays}>
 
-                        <div className="flex flex-row items-center mb-2 gap-4">
-                            <Input.Search
-                                placeholder="Search for a map"
-                                onSearch={(searchVal) => setSearchString(searchVal)}
-                            />
-                            <Tooltip title="Refresh">
-                                <Button
-                                    shape="circle"
-                                    className="mr-2"
-                                    icon={<ReloadOutlined />}
-                                    onClick={fetchMaps}
+                            <div className="flex flex-row items-center mb-2 gap-4">
+                                <Input.Search
+                                    placeholder="Search for a map"
+                                    onSearch={(searchVal) => setSearchString(searchVal)}
                                 />
-                            </Tooltip>
-                        </div>
+                                <Tooltip title="Refresh">
+                                    <Button
+                                        shape="circle"
+                                        className="mr-2"
+                                        icon={<ReloadOutlined />}
+                                        onClick={fetchMaps}
+                                    />
+                                </Tooltip>
+                            </div>
 
-                        <Table
-                            className="dojo-map-search-table"
-                            dataSource={maps}
-                            columns={columns}
-                            size="small"
-                            showSorterTooltip={false}
-                            pagination={{ defaultPageSize: 10, hideOnSinglePage: true }}
-                        />
-                    </Spin>
-                </Card>
-            </Layout.Content>
-        </Layout>
+                            <Table
+                                className="dojo-map-search-table"
+                                dataSource={maps}
+                                columns={columns}
+                                size="small"
+                                showSorterTooltip={false}
+                                pagination={{ defaultPageSize: 10, hideOnSinglePage: true }}
+                            />
+                        </Spin>
+                    </Card>
+                </div>
+            </div>
+        </div>
     );
 };
 

--- a/app/pages/maps/[mapUId]/index.tsx
+++ b/app/pages/maps/[mapUId]/index.tsx
@@ -85,7 +85,7 @@ const Home = (): JSX.Element => {
         <>
             <HeadTitle title={getTitle()} />
             <Layout>
-                <MapHeader mapInfo={mapData} />
+                <MapHeader mapInfo={mapData} title="Replay viewer" />
                 <Layout.Content>
                     <SidebarReplays
                         mapUId={`${mapUId}`}

--- a/app/pages/maps/[mapUId]/index.tsx
+++ b/app/pages/maps/[mapUId]/index.tsx
@@ -2,10 +2,10 @@ import React, { useEffect, useState } from 'react';
 import { Layout } from 'antd';
 import { useRouter } from 'next/router';
 
-import SidebarReplays from '../../components/maps/SidebarReplays';
-import SidebarSettings from '../../components/maps/SidebarSettings';
-import MapHeader from '../../components/maps/MapHeader';
-import Viewer3D from '../../components/viewer/Viewer3D';
+import SidebarReplays from '../../../components/maps/SidebarReplays';
+import SidebarSettings from '../../../components/maps/SidebarSettings';
+import MapHeader from '../../../components/maps/MapHeader';
+import Viewer3D from '../../../components/viewer/Viewer3D';
 import {
     getReplays,
     getMapInfo,
@@ -13,11 +13,11 @@ import {
     fetchReplayData,
     ReplayData,
     MapInfo,
-} from '../../lib/api/apiRequests';
-import HeadTitle from '../../components/common/HeadTitle';
-import { ChartsDrawer } from '../../components/maps/ChartsDrawer';
-import { cleanTMFormatting } from '../../lib/utils/formatting';
-import LoadedReplays from '../../components/maps/LoadedReplays';
+} from '../../../lib/api/apiRequests';
+import HeadTitle from '../../../components/common/HeadTitle';
+import { ChartsDrawer } from '../../../components/maps/ChartsDrawer';
+import { cleanTMFormatting } from '../../../lib/utils/formatting';
+import LoadedReplays from '../../../components/maps/LoadedReplays';
 
 const Home = (): JSX.Element => {
     const [replays, setReplays] = useState<FileResponse[]>([]);

--- a/app/pages/maps/[mapUId]/stats.tsx
+++ b/app/pages/maps/[mapUId]/stats.tsx
@@ -62,7 +62,7 @@ const MapStats = () => {
     return (
         <div className="min-h-screen" style={{ backgroundColor: '#1F1F1F' }}>
             <HeadTitle title={getTitle()} />
-            <MapHeader mapInfo={mapData || {}} />
+            <MapHeader mapInfo={mapData || {}} title="Map statistics" />
             {mapData && (
                 <div className="flex justify-center py-8">
                     <Card

--- a/app/pages/maps/[mapUId]/stats.tsx
+++ b/app/pages/maps/[mapUId]/stats.tsx
@@ -1,9 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import {
-    Layout, Card, Spin, Skeleton,
-} from 'antd';
-import { isNumber } from 'util';
+import { Card, Skeleton } from 'antd';
 import {
     FileResponse, getMapInfo, getReplays, MapInfo,
 } from '../../../lib/api/apiRequests';

--- a/app/pages/maps/[mapUId]/stats.tsx
+++ b/app/pages/maps/[mapUId]/stats.tsx
@@ -60,50 +60,49 @@ const MapStats = () => {
     const binSize = calcBinSize();
 
     return (
-        <>
+        <div style={{ backgroundColor: '#1F1F1F' }}>
             <HeadTitle title={getTitle()} />
-            <Layout className="h-full">
-                <MapHeader mapInfo={mapData || {}} />
-                {mapData
-                    && (
-                        <Layout.Content className="w-3/5 m-auto h-full pt-8">
+            <MapHeader mapInfo={mapData || {}} />
+            {mapData && (
+                <div className="flex justify-center py-8">
+                    <Card
+                        className="w-3/5"
+                        title={`Map: ${cleanTMFormatting(mapData?.name || '')}`}
+                    >
+                        <div className="flex flex-col h-full gap-4">
                             <Card
-                                title={`Map: ${cleanTMFormatting(mapData?.name || '')}`}
+                                title="Replays"
+                                type="inner"
                             >
-                                <div className="flex flex-col h-full gap-4">
-                                    <Card
-                                        title="Replays"
-                                        type="inner"
-                                    >
-                                        <Skeleton loading={loadingReplays} active title={false}>
-                                            <AggregateMapStats replays={replays} />
-                                        </Skeleton>
-                                    </Card>
-
-                                    <Card
-                                        title={`Finish Time Histogram ${binSize ? `(${binSize}ms bins)` : ''}`}
-                                        type="inner"
-                                    >
-                                        <Skeleton loading={loadingReplays} active>
-                                            {binSize
-                                                && <ReplayTimesHistogram replays={replays} binSize={binSize} />}
-                                        </Skeleton>
-                                    </Card>
-
-                                    <Card
-                                        title="Fastest time progression"
-                                        type="inner"
-                                    >
-                                        <Skeleton loading={loadingReplays} active>
-                                            <FastestTimeProgression replays={replays} />
-                                        </Skeleton>
-                                    </Card>
-                                </div>
+                                <Skeleton loading={loadingReplays} active title={false}>
+                                    <AggregateMapStats replays={replays} />
+                                </Skeleton>
                             </Card>
-                        </Layout.Content>
-                    )}
-            </Layout>
-        </>
+
+                            <Card
+                                title={`Finish Time Histogram ${binSize ? `(${binSize}ms bins)` : ''}`}
+                                type="inner"
+                            >
+                                <Skeleton loading={loadingReplays} active>
+                                    {binSize
+                                                && <ReplayTimesHistogram replays={replays} binSize={binSize} />}
+                                </Skeleton>
+                            </Card>
+
+                            <Card
+                                title="Fastest time progression"
+                                type="inner"
+                            >
+                                <Skeleton loading={loadingReplays} active>
+                                    <FastestTimeProgression replays={replays} />
+                                </Skeleton>
+                            </Card>
+                        </div>
+                    </Card>
+                </div>
+
+            )}
+        </div>
     );
 };
 

--- a/app/pages/maps/[mapUId]/stats.tsx
+++ b/app/pages/maps/[mapUId]/stats.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import {
+    Layout, Card, Spin, Skeleton,
+} from 'antd';
+import { isNumber } from 'util';
+import {
+    FileResponse, getMapInfo, getReplays, MapInfo,
+} from '../../../lib/api/apiRequests';
+import HeadTitle from '../../../components/common/HeadTitle';
+import { cleanTMFormatting } from '../../../lib/utils/formatting';
+import MapHeader from '../../../components/maps/MapHeader';
+import ReplayTimesHistogram from '../../../components/mapStats/ReplayTimesHistogram';
+import AggregateMapStats from '../../../components/mapStats/AggregateMapStats';
+
+const MapStats = () => {
+    const [replays, setReplays] = useState<FileResponse[]>([]);
+    const [loadingReplays, setLoadingReplays] = useState<boolean>(true);
+    const [mapData, setMapData] = useState<MapInfo>();
+
+    const router = useRouter();
+    const { mapUId } = router.query;
+
+    const fetchAndSetReplays = async () => {
+        setLoadingReplays(true);
+
+        const { files } = await getReplays({ mapUId: `${mapUId}` });
+        setReplays(files);
+
+        setLoadingReplays(false);
+    };
+
+    useEffect(() => {
+        const fetchMapData = async (mapId: string) => {
+            const mapInfo = await getMapInfo(mapId); // TODO: what happens if the map can't be found?
+            setMapData(mapInfo);
+        };
+        if (mapUId !== undefined) {
+            fetchAndSetReplays();
+            fetchMapData(`${mapUId}`);
+        }
+    }, [mapUId]);
+
+    const getTitle = () => (mapData?.name ? `${cleanTMFormatting(mapData.name)} - TMDojo` : 'TMDojo');
+
+    const calcBinSize = () => {
+        if (replays.length === 0) {
+            return undefined;
+        }
+
+        const minTime = Math.min(...replays.map((r) => r.endRaceTime));
+        const maxTime = Math.max(...replays.map((r) => r.endRaceTime));
+
+        // WIP method for determining bin size using the min and max times
+        const binSize = 10 ** (Math.floor(Math.log10(maxTime - minTime)) - 1);
+        return binSize;
+    };
+
+    const binSize = calcBinSize();
+
+    return (
+        <>
+            <HeadTitle title={getTitle()} />
+            <Layout>
+                <MapHeader mapInfo={mapData || {}} />
+                {mapData
+                    && (
+                        <Layout.Content className="w-3/5 m-auto h-full pt-8">
+                            <Card
+                                title={`Map: ${cleanTMFormatting(mapData?.name || '')}`}
+                            >
+                                <div className="flex flex-col gap-4">
+                                    <Card
+                                        title="Replays"
+                                        type="inner"
+                                    >
+                                        <Skeleton loading={loadingReplays} active title={false}>
+                                            <AggregateMapStats replays={replays} />
+                                        </Skeleton>
+                                    </Card>
+
+                                    <Card
+                                        title={`Finish Time Histogram ${binSize ? `(${binSize}ms bins)` : ''}`}
+                                        type="inner"
+                                    >
+                                        <Skeleton loading={loadingReplays} active>
+                                            {binSize
+                                                && <ReplayTimesHistogram replays={replays} binSize={binSize} />}
+                                        </Skeleton>
+                                    </Card>
+                                </div>
+                            </Card>
+                        </Layout.Content>
+                    )}
+            </Layout>
+        </>
+    );
+};
+
+export default MapStats;

--- a/app/pages/maps/[mapUId]/stats.tsx
+++ b/app/pages/maps/[mapUId]/stats.tsx
@@ -12,6 +12,7 @@ import { cleanTMFormatting } from '../../../lib/utils/formatting';
 import MapHeader from '../../../components/maps/MapHeader';
 import ReplayTimesHistogram from '../../../components/mapStats/ReplayTimesHistogram';
 import AggregateMapStats from '../../../components/mapStats/AggregateMapStats';
+import FastestTimeProgression from '../../../components/mapStats/FastestTimeProgression';
 
 const MapStats = () => {
     const [replays, setReplays] = useState<FileResponse[]>([]);
@@ -61,7 +62,7 @@ const MapStats = () => {
     return (
         <>
             <HeadTitle title={getTitle()} />
-            <Layout>
+            <Layout className="h-full">
                 <MapHeader mapInfo={mapData || {}} />
                 {mapData
                     && (
@@ -69,7 +70,7 @@ const MapStats = () => {
                             <Card
                                 title={`Map: ${cleanTMFormatting(mapData?.name || '')}`}
                             >
-                                <div className="flex flex-col gap-4">
+                                <div className="flex flex-col h-full gap-4">
                                     <Card
                                         title="Replays"
                                         type="inner"
@@ -86,6 +87,15 @@ const MapStats = () => {
                                         <Skeleton loading={loadingReplays} active>
                                             {binSize
                                                 && <ReplayTimesHistogram replays={replays} binSize={binSize} />}
+                                        </Skeleton>
+                                    </Card>
+
+                                    <Card
+                                        title="Fastest time progression"
+                                        type="inner"
+                                    >
+                                        <Skeleton loading={loadingReplays} active>
+                                            <FastestTimeProgression replays={replays} />
                                         </Skeleton>
                                     </Card>
                                 </div>

--- a/app/pages/maps/[mapUId]/stats.tsx
+++ b/app/pages/maps/[mapUId]/stats.tsx
@@ -60,7 +60,7 @@ const MapStats = () => {
     const binSize = calcBinSize();
 
     return (
-        <div style={{ backgroundColor: '#1F1F1F' }}>
+        <div className="min-h-screen" style={{ backgroundColor: '#1F1F1F' }}>
             <HeadTitle title={getTitle()} />
             <MapHeader mapInfo={mapData || {}} />
             {mapData && (


### PR DESCRIPTION
## Map Stats
Introduces Map Stats to TMDojo, a page to have some aggregated view of all the replays stored for a specific map.

Stats can be accessed through the `Stats` button on the homepage:
![image](https://user-images.githubusercontent.com/22432233/146061917-149a544e-d564-4ff0-a10e-f4f09f9b8071.png)

The stats page currently contains three different parts, which can be easily extended in the future:
1. Basic replay stats
2. Finish time histogram
3. Fastest time progression

## Statistics
### Replay Stats

Contains some basic information about the number of replays and replay time.
![image](https://user-images.githubusercontent.com/22432233/146062547-2b832acd-fba6-4362-bad4-57f8d878f3c8.png)

### Finish Time Histogram
Contains a histogram of the end times of all finished replays. The size of the number of bins is determined by the difference between min and max finish times. Based on the spread of finish times, the bin sizes can currently be 100ms, 1000ms, 10000ms, etc. 
![image](https://user-images.githubusercontent.com/22432233/146062583-4a18c5c9-e602-4300-aeb7-c7a1902d2805.png)

### Fastest Time Progression
This visualization aims to show the progression of the fastest time improvements. The blue line shows the progression of the fastest time stored on TMDojo at that time. The grey dots show the end time entries of all other replays on TMDojo.
![image](https://user-images.githubusercontent.com/22432233/146062612-6f30bc6e-47a6-4763-a3e1-2bfbfe48b351.png)


