### PR TITLE
Improve maps endpoint

### DIFF
--- a/server/src/lib/db.ts
+++ b/server/src/lib/db.ts
@@ -98,7 +98,7 @@ export const getUniqueMapNames = async (
         {
             $project: {
                 _id: false,
-                mapUId: { $toString: '$_id' },
+                mapUId: true,
                 mapName: true,
                 count: '$count',
                 lastUpdate: true,


### PR DESCRIPTION
Change order of /maps endpoint aggregate pipeline, basically doing the $group before the $lookup to avoid unnecessary lookups. Was about a 5x speedup or so at this point of the DB, from around 950ms to 200ms.