### PR TITLE
Update histogram tooltip

### DIFF
--- a/app/components/mapStats/ReplayTimesHistogram.tsx
+++ b/app/components/mapStats/ReplayTimesHistogram.tsx
@@ -1,3 +1,5 @@
+// Disable warning, used in highcharts tooltips using callback function
+/* eslint-disable react/no-this-in-sfc */
 import React from 'react';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
@@ -78,11 +80,24 @@ const ReplayTimesHistogram = ({ replays, binSize } : ReplayTimesHistogramProps) 
             },
         },
         tooltip: {
-            headerFormat: '<span style="font-size:10px">{point.key}</span><table>',
-            pointFormat: '<tr><td style="color:{series.color};padding:0">{series.name}: </td>'
-            + '<td style="padding:0"><b>{point.y:.1f} replays</b></td></tr>',
-            footerFormat: '</table>',
-            shared: true,
+            // Highchart only accepts string tooltips, that's why this returns a HTML string
+            formatter: function tooltipFormatter(this: any) {
+                console.log(typeof this);
+
+                const raceTime = parseFloat(this.x) * 1000;
+
+                return `
+                    <span style="font-size: 10px">
+                        ${getRaceTimeStr(raceTime)} - ${getRaceTimeStr(raceTime + binSize)}
+                    </span>
+                    </br>
+                    <span style="font-size: 13px">
+                        <b>
+                            <span style=color:${this.series.color}>Replays: </span>
+                            ${this.point.y}</b>
+                    </span>
+                `;
+            },
             useHTML: true,
         },
         plotOptions: {


### PR DESCRIPTION
Changes histogram tooltip to show natural numbers, plus some additional changes like what the start and end time of each bin is:

![image](https://user-images.githubusercontent.com/22432233/147877153-a6aebb09-3aac-47c5-b099-73f3a300a64e.png)
