### PR TITLE
Personal Map Statistics

### DIFF
--- a/app/.eslintrc.js
+++ b/app/.eslintrc.js
@@ -3,7 +3,11 @@ module.exports = {
         browser: true,
         es2021: true,
     },
-    extends: ['plugin:react/recommended', 'airbnb'],
+    extends: [
+        'plugin:react/recommended',
+        'airbnb',
+        'plugin:react-hooks/recommended',
+    ],
     globals: {
         React: true,
         JSX: true,

--- a/app/.eslintrc.js
+++ b/app/.eslintrc.js
@@ -49,6 +49,8 @@ module.exports = {
         'no-plusplus': 'off',
         'max-len': ['error', 120],
         'lines-between-class-members': 'off',
+        'no-shadow': 'off',
+        '@typescript-eslint/no-shadow': 'error',
     },
     settings: {
         'import/resolver': {

--- a/app/components/mapStats/common/MapStatsTypeSwitcher.tsx
+++ b/app/components/mapStats/common/MapStatsTypeSwitcher.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { Button, Card } from 'antd';
 import { MapInfo } from '../../../lib/api/apiRequests';
 import { AuthContext } from '../../../lib/contexts/AuthContext';
+import { cleanTMFormatting } from '../../../lib/utils/formatting';
 
 export enum MapStatsType {
     GLOBAL = 'Global',
@@ -31,7 +32,7 @@ export const MapStatsTypeSwitcher = ({ mapStatsType, mapData, toggleMapStatsType
                     <>
                         {'for '}
                         <b>
-                            {mapData.name}
+                            {cleanTMFormatting(mapData.name)}
                         </b>
                     </>
                 )}

--- a/app/components/mapStats/common/MapStatsTypeSwitcher.tsx
+++ b/app/components/mapStats/common/MapStatsTypeSwitcher.tsx
@@ -1,0 +1,63 @@
+import React, { useContext } from 'react';
+import { Button, Card } from 'antd';
+import { MapInfo } from '../../../lib/api/apiRequests';
+import { AuthContext } from '../../../lib/contexts/AuthContext';
+
+export enum MapStatsType {
+    GLOBAL = 'Global',
+    PERSONAL = 'Personal'
+}
+
+interface MapStatsTypeSwitcherProps {
+    mapStatsType: MapStatsType;
+    mapData: MapInfo;
+    toggleMapStatsType: () => void;
+}
+export const MapStatsTypeSwitcher = ({ mapStatsType, mapData, toggleMapStatsType } : MapStatsTypeSwitcherProps) => {
+    const { user, startAuthFlow } = useContext(AuthContext);
+
+    return (
+        <div className="flex flex-col gap-4 items-center">
+            <div className="text-xl">
+                You are currently viewing
+                {' '}
+                {mapStatsType === MapStatsType.GLOBAL ? 'the' : 'your'}
+                {' '}
+                <b>{mapStatsType}</b>
+                {' '}
+                statistics
+                {' '}
+                {mapData.name && (
+                    <>
+                        {'for '}
+                        <b>
+                            {mapData.name}
+                        </b>
+                    </>
+                )}
+            </div>
+            {user
+                ? (
+                    <Button
+                        type="ghost"
+                        onClick={toggleMapStatsType}
+                    >
+                        Switch to
+                        {' '}
+                        {mapStatsType === MapStatsType.GLOBAL
+                            ? MapStatsType.PERSONAL
+                            : MapStatsType.GLOBAL}
+                        {' '}
+                        statistics
+                    </Button>
+                ) : (
+                    <Button
+                        type="ghost"
+                        onClick={startAuthFlow}
+                    >
+                        Log in to view your personal statistics
+                    </Button>
+                )}
+        </div>
+    );
+};

--- a/app/components/mapStats/common/MapStatsTypeSwitcher.tsx
+++ b/app/components/mapStats/common/MapStatsTypeSwitcher.tsx
@@ -9,6 +9,13 @@ export enum MapStatsType {
     PERSONAL = 'Personal'
 }
 
+const oppositeType = (type: MapStatsType) => {
+    if (type === MapStatsType.GLOBAL) {
+        return MapStatsType.PERSONAL;
+    }
+    return MapStatsType.GLOBAL;
+};
+
 interface MapStatsTypeSwitcherProps {
     mapStatsType: MapStatsType;
     mapData: MapInfo;
@@ -20,20 +27,13 @@ export const MapStatsTypeSwitcher = ({ mapStatsType, mapData, toggleMapStatsType
     return (
         <div className="flex flex-col gap-4 items-center">
             <div className="text-xl">
-                You are currently viewing
-                {' '}
-                {mapStatsType === MapStatsType.GLOBAL ? 'the' : 'your'}
-                {' '}
+                {`You are currently viewing ${mapStatsType === MapStatsType.GLOBAL ? 'the' : 'your'} `}
                 <b>{mapStatsType}</b>
-                {' '}
-                statistics
-                {' '}
+                {' statistics'}
                 {mapData.name && (
                     <>
-                        {'for '}
-                        <b>
-                            {cleanTMFormatting(mapData.name)}
-                        </b>
+                        {' for '}
+                        <b>{cleanTMFormatting(mapData.name)}</b>
                     </>
                 )}
             </div>
@@ -43,13 +43,7 @@ export const MapStatsTypeSwitcher = ({ mapStatsType, mapData, toggleMapStatsType
                         type="ghost"
                         onClick={toggleMapStatsType}
                     >
-                        Switch to
-                        {' '}
-                        {mapStatsType === MapStatsType.GLOBAL
-                            ? MapStatsType.PERSONAL
-                            : MapStatsType.GLOBAL}
-                        {' '}
-                        statistics
+                        {`Switch to ${oppositeType(mapStatsType)} statistics`}
                     </Button>
                 ) : (
                     <Button

--- a/app/components/mapStats/statistics/AggregateMapStats.tsx
+++ b/app/components/mapStats/statistics/AggregateMapStats.tsx
@@ -1,7 +1,7 @@
 import { Col, Row, Statistic } from 'antd';
 import React from 'react';
-import { FileResponse } from '../../lib/api/apiRequests';
-import { msToTime } from '../../lib/utils/time';
+import { FileResponse } from '../../../lib/api/apiRequests';
+import { msToTime } from '../../../lib/utils/time';
 
 interface AggregateMapStatsProps {
     replays: FileResponse[];

--- a/app/components/mapStats/statistics/FastestTimeProgression.tsx
+++ b/app/components/mapStats/statistics/FastestTimeProgression.tsx
@@ -59,7 +59,7 @@ const FastestTimeProgression = ({
             const filteredReplays = filterReplaysByUser(userToShowProgression, finishedReplays);
             return replaysToProgressionDataPoints(filteredReplays);
         },
-        [finishedReplays],
+        [userToShowProgression, finishedReplays],
     );
 
     const allDataPoints: ChartDataPoint[] = useMemo(

--- a/app/components/mapStats/statistics/FastestTimeProgression.tsx
+++ b/app/components/mapStats/statistics/FastestTimeProgression.tsx
@@ -5,9 +5,9 @@ import React, { useMemo } from 'react';
 import Highcharts, { some } from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import dayjs from 'dayjs';
-import { getRaceTimeStr, timeDifference } from '../../lib/utils/time';
-import { FileResponse } from '../../lib/api/apiRequests';
-import PlayerLink from '../common/PlayerLink';
+import { getRaceTimeStr, timeDifference } from '../../../lib/utils/time';
+import { FileResponse } from '../../../lib/api/apiRequests';
+import PlayerLink from '../../common/PlayerLink';
 
 interface FastestTimeProgressionProps {
     replays: FileResponse[];

--- a/app/components/mapStats/statistics/FastestTimeProgression.tsx
+++ b/app/components/mapStats/statistics/FastestTimeProgression.tsx
@@ -7,58 +7,78 @@ import HighchartsReact from 'highcharts-react-official';
 import dayjs from 'dayjs';
 import { getRaceTimeStr, timeDifference } from '../../../lib/utils/time';
 import { FileResponse } from '../../../lib/api/apiRequests';
+import calculateFastestTimeProgressions from '../../../lib/utils/fastestTimeProgression';
 import PlayerLink from '../../common/PlayerLink';
+import { UserInfo } from '../../../lib/api/auth';
+
+interface ChartDataPoint {
+    x: number;
+    y: number;
+    replay: FileResponse;
+}
+
+const replaysToDataPoints = (replays_: FileResponse[]): ChartDataPoint[] => replays_.map((replay) => ({
+    x: replay.date,
+    y: replay.endRaceTime,
+    replay,
+}));
+
+const replaysToProgressionDataPoints = (replays: FileResponse[]) => {
+    const progression = calculateFastestTimeProgressions(replays);
+    const dataPoints = replaysToDataPoints(progression);
+    return dataPoints;
+};
+
+const filterReplaysByUser = (loggedInUser: UserInfo, inputReplays: FileResponse[]) => {
+    const filtered = inputReplays.filter((r) => r.webId === loggedInUser.accountId);
+    return filtered;
+};
 
 interface FastestTimeProgressionProps {
     replays: FileResponse[];
+    onlyShowUserProgression: boolean;
+    userToShowProgression?: UserInfo;
 }
-const FastestTimeProgression = ({ replays } : FastestTimeProgressionProps) => {
-    const calculateFastestTimeProgressions = (replayList: FileResponse[]): FileResponse[] => {
-        if (replayList.length === 0) {
-            return [];
-        }
-
-        const fastestTimeProgressions: FileResponse[] = [];
-        const sortedReplays = replayList.sort((a, b) => a.date - b.date);
-
-        fastestTimeProgressions.push(sortedReplays[0]);
-        for (let i = 1; i < sortedReplays.length; i++) {
-            const currentReplay = sortedReplays[i];
-            const latestFastestReplay = fastestTimeProgressions[fastestTimeProgressions.length - 1];
-            if (currentReplay.raceFinished
-                && currentReplay.endRaceTime < latestFastestReplay.endRaceTime) {
-                fastestTimeProgressions.push(currentReplay);
-            }
-        }
-        return fastestTimeProgressions;
-    };
-
-    interface ChartDataPoint {
-        x: number;
-        y: number;
-        replay: FileResponse;
-    }
-
-    const fastestTimeProgressions = useMemo(() => calculateFastestTimeProgressions(replays), [replays]);
-
-    const replaysToDataPoints = (replays_: FileResponse[]): ChartDataPoint[] => replays_.map((replay) => ({
-        x: replay.date,
-        y: replay.endRaceTime,
-        replay,
-    }));
+const FastestTimeProgression = ({
+    replays,
+    onlyShowUserProgression,
+    userToShowProgression,
+} : FastestTimeProgressionProps) => {
+    const finishedReplays = useMemo(() => replays.filter((r) => r.raceFinished === 1), [replays]);
 
     const timeProgressionData: ChartDataPoint[] = useMemo(
-        () => replaysToDataPoints(fastestTimeProgressions),
-        [fastestTimeProgressions],
+        () => replaysToProgressionDataPoints(replays),
+        [replays],
+    );
+
+    const personalTimeProgressionData: ChartDataPoint[] | undefined = useMemo(
+        () => {
+            if (userToShowProgression === undefined) {
+                return undefined;
+            }
+            const filteredReplays = filterReplaysByUser(userToShowProgression, finishedReplays);
+            return replaysToProgressionDataPoints(filteredReplays);
+        },
+        [finishedReplays],
     );
 
     const allDataPoints: ChartDataPoint[] = useMemo(
-        () => replaysToDataPoints(
-            replays.filter(
+        () => {
+            let filteredReplays = finishedReplays;
+
+            filteredReplays = filteredReplays.filter(
                 (r1) => !some(timeProgressionData, (r2: ChartDataPoint) => r1._id === r2.replay._id, null),
-            ),
-        ),
-        [replays, timeProgressionData],
+            );
+
+            if (personalTimeProgressionData) {
+                filteredReplays = filteredReplays.filter(
+                    (r1) => !some(personalTimeProgressionData, (r2: ChartDataPoint) => r1._id === r2.replay._id, null),
+                );
+            }
+
+            return replaysToDataPoints(filteredReplays);
+        },
+        [finishedReplays, timeProgressionData, personalTimeProgressionData],
     );
 
     const options = {
@@ -157,8 +177,16 @@ const FastestTimeProgression = ({ replays } : FastestTimeProgressionProps) => {
         series: [{
             type: 'line',
             name: 'Best Times',
-            data: timeProgressionData,
+            // Set timeProgressionData to undefined to disable the line when only showing user progression
+            data: onlyShowUserProgression ? undefined : timeProgressionData,
             step: 'left',
+            color: 'green',
+        }, {
+            type: 'line',
+            name: 'Personal Best Times',
+            data: personalTimeProgressionData,
+            step: 'left',
+            color: 'orange',
         }, {
             type: 'scatter',
             name: 'Other Times',
@@ -167,9 +195,18 @@ const FastestTimeProgression = ({ replays } : FastestTimeProgressionProps) => {
         }],
     };
 
-    const fastestTime = timeProgressionData.length > 0
+    // Filter series for which the data is undefined
+    options.series = options.series.filter((s) => s.data !== undefined);
+
+    const allFastestTime = timeProgressionData && timeProgressionData.length > 0
         ? timeProgressionData[timeProgressionData.length - 1]
         : undefined;
+
+    const personalFastestTime = personalTimeProgressionData !== undefined && personalTimeProgressionData.length > 0
+        ? personalTimeProgressionData[personalTimeProgressionData.length - 1]
+        : undefined;
+
+    const fastestTime = allFastestTime || personalFastestTime;
 
     return (
         fastestTime ? (

--- a/app/components/mapStats/statistics/ReplayTimesHistogram.tsx
+++ b/app/components/mapStats/statistics/ReplayTimesHistogram.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import bellcurve from 'highcharts/modules/histogram-bellcurve';
-import { getRaceTimeStr } from '../../lib/utils/time';
-import { FileResponse } from '../../lib/api/apiRequests';
+import { getRaceTimeStr } from '../../../lib/utils/time';
+import { FileResponse } from '../../../lib/api/apiRequests';
 
 if (typeof Highcharts === 'object') {
     bellcurve(Highcharts);

--- a/app/lib/utils/fastestTimeProgression.ts
+++ b/app/lib/utils/fastestTimeProgression.ts
@@ -1,0 +1,23 @@
+import { FileResponse } from '../api/apiRequests';
+
+const calculateFastestTimeProgression = (replayList: FileResponse[]): FileResponse[] => {
+    if (replayList.length === 0) {
+        return [];
+    }
+
+    const fastestTimeProgressions: FileResponse[] = [];
+    const sortedReplays = replayList.sort((a, b) => a.date - b.date);
+
+    fastestTimeProgressions.push(sortedReplays[0]);
+    for (let i = 1; i < sortedReplays.length; i++) {
+        const currentReplay = sortedReplays[i];
+        const latestFastestReplay = fastestTimeProgressions[fastestTimeProgressions.length - 1];
+        if (currentReplay.raceFinished
+            && currentReplay.endRaceTime < latestFastestReplay.endRaceTime) {
+            fastestTimeProgressions.push(currentReplay);
+        }
+    }
+    return fastestTimeProgressions;
+};
+
+export default calculateFastestTimeProgression;

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -44,7 +44,7 @@
         "eslint-plugin-import": "^2.23.3",
         "eslint-plugin-jsx-a11y": "^6.4.1",
         "eslint-plugin-react": "^7.23.2",
-        "eslint-plugin-react-hooks": "^4.2.0",
+        "eslint-plugin-react-hooks": "^4.3.0",
         "postcss": "^8.2.8",
         "typescript": "^4.2.3"
       }
@@ -5580,15 +5580,15 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
-      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
+      "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
       "dev": true,
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
@@ -14820,9 +14820,9 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
-      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
+      "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
       "dev": true,
       "requires": {}
     },

--- a/app/package.json
+++ b/app/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-import": "^2.23.3",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.23.2",
-    "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-react-hooks": "^4.3.0",
     "postcss": "^8.2.8",
     "typescript": "^4.2.3"
   }

--- a/app/pages/maps/[mapUId]/stats.tsx
+++ b/app/pages/maps/[mapUId]/stats.tsx
@@ -2,7 +2,7 @@ import React, {
     useContext, useEffect, useMemo, useState,
 } from 'react';
 import { useRouter } from 'next/router';
-import { Card, Skeleton } from 'antd';
+import { Card, Empty, Skeleton } from 'antd';
 import {
     FileResponse, getMapInfo, getReplays, MapInfo,
 } from '../../../lib/api/apiRequests';
@@ -116,33 +116,43 @@ const MapStats = () => {
                         title={`Map: ${cleanTMFormatting(mapData?.name || '')}`}
                     >
                         <div className="flex flex-col h-full gap-4">
-                            <Card
-                                title="Replays"
-                                type="inner"
-                            >
-                                <Skeleton loading={loadingReplays} active title={false}>
-                                    <AggregateMapStats replays={filteredReplays} />
-                                </Skeleton>
-                            </Card>
+                            {filteredReplays.length === 0
+                                ? (
+                                    <Empty
+                                        image={Empty.PRESENTED_IMAGE_SIMPLE}
+                                        description="No finished replays"
+                                    />
+                                ) : (
+                                    <>
+                                        <Card
+                                            title="Replays"
+                                            type="inner"
+                                        >
+                                            <Skeleton loading={loadingReplays} active title={false}>
+                                                <AggregateMapStats replays={filteredReplays} />
+                                            </Skeleton>
+                                        </Card>
 
-                            <Card
-                                title={`Finish Time Histogram ${binSize ? `(${binSize}ms bins)` : ''}`}
-                                type="inner"
-                            >
-                                <Skeleton loading={loadingReplays} active>
-                                    {binSize
+                                        <Card
+                                            title={`Finish Time Histogram ${binSize ? `(${binSize}ms bins)` : ''}`}
+                                            type="inner"
+                                        >
+                                            <Skeleton loading={loadingReplays} active>
+                                                {binSize
                                         && <ReplayTimesHistogram replays={filteredReplays} binSize={binSize} />}
-                                </Skeleton>
-                            </Card>
+                                            </Skeleton>
+                                        </Card>
 
-                            <Card
-                                title="Fastest time progression"
-                                type="inner"
-                            >
-                                <Skeleton loading={loadingReplays} active>
-                                    <FastestTimeProgression replays={filteredReplays} />
-                                </Skeleton>
-                            </Card>
+                                        <Card
+                                            title="Fastest time progression"
+                                            type="inner"
+                                        >
+                                            <Skeleton loading={loadingReplays} active>
+                                                <FastestTimeProgression replays={filteredReplays} />
+                                            </Skeleton>
+                                        </Card>
+                                    </>
+                                )}
                         </div>
                     </Card>
                 </div>

--- a/app/pages/maps/[mapUId]/stats.tsx
+++ b/app/pages/maps/[mapUId]/stats.tsx
@@ -121,7 +121,7 @@ const MapStats = () => {
                                 ? (
                                     <Empty
                                         image={Empty.PRESENTED_IMAGE_SIMPLE}
-                                        description="No finished replays"
+                                        description="No finished replays yet"
                                     />
                                 ) : (
                                     <>


### PR DESCRIPTION
Adds personal map statistics to the map stats page. When a user is logged in, the user can toggle between Global and Personal stats using a button at the top. When the user is not logged in, a button is shown that allows the user to log in.

#### User not logged in, default is Global statistics:
![image](https://user-images.githubusercontent.com/22432233/147881165-410ed040-3f5c-499b-9b9c-21922e2bf131.png)

#### User logs in, automatically switching to Personal statistics:
![image](https://user-images.githubusercontent.com/22432233/147881138-35525fca-5a16-4596-8918-5f7647e1edbd.png)

#### User switches to Global statistics:
![image](https://user-images.githubusercontent.com/22432233/147881145-11b5bb26-c9bb-4346-91f6-5197bf82f5c1.png)

#### Personal statistics without replays
![image](https://user-images.githubusercontent.com/22432233/147881858-da14f14b-3450-441b-bc8a-17e3a4810788.png)

