### PR TITLE
Set map stats type to global if the user has no replays

### DIFF
--- a/app/pages/maps/[mapUId]/stats.tsx
+++ b/app/pages/maps/[mapUId]/stats.tsx
@@ -50,12 +50,19 @@ const MapStats = () => {
 
     // If user object changes, set the according map stats type
     useEffect(() => {
-        if (user === undefined) {
-            setMapStatsType(MapStatsType.GLOBAL);
-        } else {
-            setMapStatsType(MapStatsType.PERSONAL);
+        if (replays) {
+            if (user === undefined) {
+                setMapStatsType(MapStatsType.GLOBAL);
+            } else {
+                const userReplays = replays.filter((r) => r.webId === user.accountId);
+                if (userReplays.length > 0) {
+                    setMapStatsType(MapStatsType.PERSONAL);
+                } else {
+                    setMapStatsType(MapStatsType.GLOBAL);
+                }
+            }
         }
-    }, [user]);
+    }, [replays, user]);
 
     const getTitle = () => (mapData?.name ? `${cleanTMFormatting(mapData.name)} - TMDojo` : 'TMDojo');
 


### PR DESCRIPTION
Do not set map stats type to personal when the user has no replays. Avoid having the user always click the "Switch to Global statistics" if someone just wants to browse some statistics.