### PR TITLE
[Update] Personal Map Stats - stay on global if user has no replays

### DIFF
--- a/app/components/mapStats/statistics/ReplayTimesHistogram.tsx
+++ b/app/components/mapStats/statistics/ReplayTimesHistogram.tsx
@@ -82,8 +82,6 @@ const ReplayTimesHistogram = ({ replays, binSize } : ReplayTimesHistogramProps) 
         tooltip: {
             // Highchart only accepts string tooltips, that's why this returns a HTML string
             formatter: function tooltipFormatter(this: any) {
-                console.log(typeof this);
-
                 const raceTime = parseFloat(this.x) * 1000;
 
                 return `

--- a/app/pages/maps/[mapUId]/stats.tsx
+++ b/app/pages/maps/[mapUId]/stats.tsx
@@ -50,12 +50,19 @@ const MapStats = () => {
 
     // If user object changes, set the according map stats type
     useEffect(() => {
-        if (user === undefined) {
-            setMapStatsType(MapStatsType.GLOBAL);
-        } else {
-            setMapStatsType(MapStatsType.PERSONAL);
+        if (replays) {
+            if (user === undefined) {
+                setMapStatsType(MapStatsType.GLOBAL);
+            } else {
+                const userReplays = replays.filter((r) => r.webId === user.accountId);
+                if (userReplays.length > 0) {
+                    setMapStatsType(MapStatsType.PERSONAL);
+                } else {
+                    setMapStatsType(MapStatsType.GLOBAL);
+                }
+            }
         }
-    }, [user]);
+    }, [replays, user]);
 
     const getTitle = () => (mapData?.name ? `${cleanTMFormatting(mapData.name)} - TMDojo` : 'TMDojo');
 


### PR DESCRIPTION
Small update to the website. Previously, when a user was logged in, they would always go to the personal stats if they go to the map statistics page. Now, they only go to that page if they actually have replays on that map.

### PRs
- #120 