### PR TITLE
Fix null user ids

### DIFF
--- a/server/src/lib/db.ts
+++ b/server/src/lib/db.ts
@@ -379,7 +379,7 @@ export const createSession = async (req: Request, userInfo: any, clientCode?: an
     // Find user
     const user = await getUserByWebId(userInfo.account_id);
     let userID = user?._id;
-    if (user === undefined || user === null) {
+    if (!userID) {
         const playerLogin = playerLoginFromWebId(req, userInfo.account_id);
 
         if (playerLogin === undefined) {

--- a/server/src/lib/db.ts
+++ b/server/src/lib/db.ts
@@ -163,8 +163,14 @@ export const saveUser = (
     userData: any,
 ): Promise<{_id: string}> => new Promise((resolve: Function, reject: Rejector) => {
     const users = db.collection('users');
-    // if _id is not defined, the upsert option will ensure a new document is created
-    users.replaceOne({ _id: userData._id }, userData, { upsert: true })
+    const cleanUserData = { ...userData };
+
+    // if _id is not valid, remove it to be certain the db doesn't try to use it
+    if (!cleanUserData._id) {
+        delete cleanUserData._id;
+    }
+
+    users.replaceOne({ _id: cleanUserData._id }, cleanUserData, { upsert: true })
         .then(({ insertedId }: {insertedId: string}) => resolve({ _id: insertedId }))
         .catch((error: Error) => reject(error));
 });

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -43,7 +43,7 @@ router.get('/', async (req: Request, res: Response, next: Function) => {
         }
 
         // make sure user exists and store clientCode in user's document
-        await db.createUser(req.query.webid, req.query.login, req.query.name, clientCode);
+        await db.createUser(req, req.query.webid, req.query.login, req.query.name, clientCode);
 
         // generate OAuth URL
         let authURL = 'https://api.trackmania.com/oauth/authorize';

--- a/server/src/routes/authorize.ts
+++ b/server/src/routes/authorize.ts
@@ -64,7 +64,7 @@ router.post('/', async (req: Request, res: Response, next: Function) => {
             req.log.debug('authorizeRouter: clientCode exists, creating plugin session');
             // remove clientCode from user
             delete userDoc.clientCode;
-            await createUser(userDoc.webId, userDoc.playerLogin, userDoc.playerName, null);
+            await createUser(req, userDoc.webId, userDoc.playerLogin, userDoc.playerName, null);
 
             // create a new plugin session including the clientCode
             await createSession(req, userInfo, clientCode);

--- a/server/src/routes/authorize.ts
+++ b/server/src/routes/authorize.ts
@@ -2,7 +2,9 @@ import { Request, Response } from 'express';
 import * as express from 'express';
 import { exchangeCodeForAccessToken, fetchUserInfo, setSessionCookie } from '../lib/authorize';
 
-import { createSession, getUserByWebId, saveUser } from '../lib/db';
+import {
+    createSession, createUser, getUserByWebId,
+} from '../lib/db';
 
 const router = express.Router();
 
@@ -62,7 +64,7 @@ router.post('/', async (req: Request, res: Response, next: Function) => {
             req.log.debug('authorizeRouter: clientCode exists, creating plugin session');
             // remove clientCode from user
             delete userDoc.clientCode;
-            await saveUser(userDoc);
+            await createUser(userDoc.webId, userDoc.playerLogin, userDoc.playerName, null);
 
             // create a new plugin session including the clientCode
             await createSession(req, userInfo, clientCode);

--- a/server/src/routes/replays.ts
+++ b/server/src/routes/replays.ts
@@ -141,20 +141,20 @@ router.post('/', (req: Request, res: Response, next: Function): any => {
             }
 
             // check if user already exists
-            let user = await db.getUserByWebId(`${req.query.webId}`);
+            const user = await db.getUserByWebId(`${req.query.webId}`);
+            let userID = user?._id;
             if (!user) {
                 req.log.debug('replaysRouter: User does not exist in database, creating new user');
-                user = await db.saveUser({
-                    playerName: req.query.playerName,
-                    playerLogin: req.query.playerLogin,
-                    webId: req.query.webId,
-                });
+                const updatedUserInfo = await db.createUser(
+                    req.query.webId, req.query.playerLogin, req.query.playerName, null,
+                );
+                userID = updatedUserInfo.insertedId;
             }
 
             const metadata = {
                 // reference map and user docs
                 mapRef: map._id,
-                userRef: user._id,
+                userRef: userID,
                 date: Date.now(),
                 raceFinished: parseInt(`${req.query.raceFinished}`, 10),
                 endRaceTime: parseInt(`${req.query.endRaceTime}`, 10),

--- a/server/src/routes/replays.ts
+++ b/server/src/routes/replays.ts
@@ -148,7 +148,7 @@ router.post('/', (req: Request, res: Response, next: Function): any => {
                 const updatedUserInfo = await db.createUser(
                     req.query.webId, req.query.playerLogin, req.query.playerName, null,
                 );
-                userID = updatedUserInfo.insertedId;
+                userID = updatedUserInfo.userID;
             }
 
             const metadata = {

--- a/server/src/routes/replays.ts
+++ b/server/src/routes/replays.ts
@@ -146,7 +146,7 @@ router.post('/', (req: Request, res: Response, next: Function): any => {
             if (!userID) {
                 req.log.debug('replaysRouter: User does not exist in database, creating new user');
                 const updatedUserInfo = await db.createUser(
-                    req.query.webId, req.query.playerLogin, req.query.playerName, null,
+                    req, req.query.webId, req.query.playerLogin, req.query.playerName, null,
                 );
                 userID = updatedUserInfo.userID;
             }

--- a/server/src/routes/replays.ts
+++ b/server/src/routes/replays.ts
@@ -143,7 +143,7 @@ router.post('/', (req: Request, res: Response, next: Function): any => {
             // check if user already exists
             const user = await db.getUserByWebId(`${req.query.webId}`);
             let userID = user?._id;
-            if (!user) {
+            if (!userID) {
                 req.log.debug('replaysRouter: User does not exist in database, creating new user');
                 const updatedUserInfo = await db.createUser(
                     req.query.webId, req.query.playerLogin, req.query.playerName, null,


### PR DESCRIPTION
As discussed, there's an edge case where new user objects could get the ID `null` since `_id` was not set during creation.
Instead of fixing a duplicate function I removed `saveUser` entirely and replaced it with the already existing `createUser` one - with some additions so we can still get the resulting userID afterwards.