### PR TITLE
Fix user upsert logic

### DIFF
--- a/server/src/lib/db.ts
+++ b/server/src/lib/db.ts
@@ -67,14 +67,15 @@ export const createUser = (
                             clientCode: clientCode || null,
                         },
                     };
-                    const updatedUserData = await users.updateOne(
+                    await users.updateOne(
                         {
                             webId,
                         },
                         updatedUser,
                     );
                     req.log.debug(`createUser: Updated user "${name}"`);
-                    resolve({ userID: updatedUserData.upsertedId?.toString() });
+                    // inserts are explicit, this will always be an existing doc (so passing the known ID is fine)
+                    resolve({ userID: docs[0]._id.toString() });
                 }
             });
     },

--- a/server/src/lib/db.ts
+++ b/server/src/lib/db.ts
@@ -56,7 +56,7 @@ export const createUser = (
                     req.log.debug(
                         `createUser: Created new user "${name}", doc ID: ${insertedUserData.insertedId.toString()}`,
                     );
-                    resolve({ userID: insertedUserData.insertedId.toString() });
+                    resolve({ userID: insertedUserData.insertedId?.toString() });
                 } else {
                     req.log.debug(`createUser: User "${name}" already exists, doc ID: ${docs[0]._id.toString()}`);
                     const updatedUser = {
@@ -74,7 +74,7 @@ export const createUser = (
                         updatedUser,
                     );
                     req.log.debug(`createUser: Updated user "${name}"`);
-                    resolve({ userID: updatedUserData.upsertedId.toString() });
+                    resolve({ userID: updatedUserData.upsertedId?.toString() });
                 }
             });
     },


### PR DESCRIPTION
`upsertedId` will always be `null` because we explicitly perform inserts separately. Instead we can just reuse the existing doc ID we use for the update anyway.