### PR TITLE
Extract logging middleware + init req id before auth

### DIFF
--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from 'express';
 import { getUserBySessionId } from '../lib/db';
-import { logDebug, logWarn } from '../lib/logger';
 
 /**
  * Authentication middleware.
@@ -13,15 +12,15 @@ const authMiddleware = async (req: Request, res: Response, next: Function) => {
 
     let sessionId;
     if (req.cookies && req.cookies.sessionId) { // UI uses cookies (sessionId)
-        logDebug('authMiddleware: Using sessionId cookie for authentication');
+        req.log.debug('authMiddleware: Using sessionId cookie for authentication');
         sessionId = req.cookies.sessionId;
     } else if (authHeader && authHeader.startsWith('dojo ')) { // plugin uses auth header ("dojo <sessionId>")
-        logDebug('authMiddleware: Using Authorization header for authentication');
+        req.log.debug('authMiddleware: Using Authorization header for authentication');
         sessionId = authHeader.substring(5);
     }
 
     if (!sessionId || typeof sessionId !== 'string') {
-        logDebug('authMiddleware: No sessionId found, continuing without authentication');
+        req.log.debug('authMiddleware: No sessionId found, continuing without authentication');
         // no sessionId and no auth header, so no user
         req.user = undefined;
         return next();
@@ -30,12 +29,12 @@ const authMiddleware = async (req: Request, res: Response, next: Function) => {
     // Get user by session secret
     const user = await getUserBySessionId(sessionId);
     if (user === undefined || user === null) {
-        logWarn(`authMiddleware: No user with sessionId ${sessionId} found, continuing without authentication`);
+        req.log.debug(`authMiddleware: No user with sessionId ${sessionId} found, continuing without authentication`);
         req.user = undefined;
         return next();
     }
 
-    logDebug(`authMiddleware: User ${user.playerName}/${user.webId} authenticated`);
+    req.log.debug(`authMiddleware: User ${user.playerName}/${user.webId} authenticated`);
     req.user = user;
     return next();
 };

--- a/server/src/middleware/reqResLogger.ts
+++ b/server/src/middleware/reqResLogger.ts
@@ -1,0 +1,20 @@
+import { Request, Response } from 'express';
+
+/**
+ * Logs request and response information.
+ */
+const reqResLoggerMiddleware = async (req: Request, res: Response, next: Function) => {
+    req.log.info(`REQUEST: ${req.method} ${req.originalUrl}`);
+
+    // override end() for logging
+    const oldEnd = res.end;
+    res.end = (data: any) => {
+        // data contains the response body
+        req.log.info(`RESPONSE: ${req.method} ${req.originalUrl} - ${res.statusCode}`);
+        oldEnd.apply(res, [data]);
+    };
+
+    return next();
+};
+
+export default reqResLoggerMiddleware;

--- a/server/src/middleware/setupLogger.ts
+++ b/server/src/middleware/setupLogger.ts
@@ -1,0 +1,14 @@
+import { Request, Response } from 'express';
+import { v4 as uuid } from 'uuid';
+import { getRequestLogger } from '../lib/logger';
+
+/**
+ * Assigns the logger and request ID to the incoming request.
+ */
+const setupLoggerMiddleware = async (req: Request, res: Response, next: Function) => {
+    req.log = getRequestLogger(req);
+    req.requestId = uuid();
+    return next();
+};
+
+export default setupLoggerMiddleware;


### PR DESCRIPTION
Extracts some initialization of the logger and request ID and moves this initialization before the auth middleware, so the request ID is available in the auth middleware for logging.