### PR TITLE
Use correct bin size for personal replays

### DIFF
--- a/app/pages/maps/[mapUId]/stats.tsx
+++ b/app/pages/maps/[mapUId]/stats.tsx
@@ -83,8 +83,6 @@ const MapStats = () => {
         return binSize;
     };
 
-    const binSize = useMemo(() => calcBinSize(replays), [replays]);
-
     const toggleMapStatsType = () => {
         if (mapStatsType === MapStatsType.GLOBAL) {
             setMapStatsType(MapStatsType.PERSONAL);
@@ -107,6 +105,9 @@ const MapStats = () => {
         },
         [user, replays, mapStatsType],
     );
+
+    const binSize = useMemo(() => calcBinSize(allReplaysFilteredByCurrentUser),
+        [allReplaysFilteredByCurrentUser]);
 
     return (
         <div className="flex flex-col items-center min-h-screen bg-page-back">


### PR DESCRIPTION
The stats page always used the global bin size, even for the personal histogram. This PR changes the bin size calculation to use the currently filtered replays, instead of all replays.