### PR TITLE
Add user count to new user webhook alert

### DIFF
--- a/server/src/lib/db.ts
+++ b/server/src/lib/db.ts
@@ -59,7 +59,8 @@ export const createUser = (
                         `createUser: Created new user "${name}", doc ID: ${insertedUserData.insertedId.toString()}`,
                     );
 
-                    DiscordWebhook.sendNewUserAlert(req, name);
+                    // Send discord alert for new user
+                    DiscordWebhook.sendNewUserAlert(req, name, users);
 
                     resolve({ userID: insertedUserData.insertedId?.toString() });
                 } else {

--- a/server/src/lib/discordWebhooks/discordWebhook.ts
+++ b/server/src/lib/discordWebhooks/discordWebhook.ts
@@ -1,23 +1,31 @@
 import { Request } from 'express';
+import { Collection, Document } from 'mongodb';
 import { sendWebhookPayload, WebhookType } from './util';
 
 export namespace DiscordWebhook {
-    export const sendNewUserAlert = async (req: Request, name: string) => {
-        const webhookType = WebhookType.INTERNAL;
+    export const sendNewUserAlert = async (req: Request, name: string, usersCollection: Collection<Document>) => {
+        try {
+            const webhookType = WebhookType.INTERNAL;
 
-        req.log.debug(`DiscordWebhook: Sending ${webhookType} discord alert for new user: ${name}`);
+            req.log.debug(`DiscordWebhook: Sending ${webhookType} discord alert for new user: ${name}`);
 
-        const body = {
-            embeds: [{
-                author: {
-                    name: 'New user!',
-                    icon_url: 'https://i.imgur.com/ubkzobI.jpg',
-                },
-                title: name,
-                color: '11964344', // hex color -> integer
-            }],
-        };
+            // Perform count in webhook method to not block main response flow
+            const numUsers = await usersCollection.countDocuments();
 
-        await sendWebhookPayload(req, webhookType, body);
+            const body = {
+                embeds: [{
+                    author: {
+                        name: `New user! #${numUsers}`,
+                        icon_url: 'https://i.imgur.com/ubkzobI.jpg',
+                    },
+                    title: name,
+                    color: '11964344', // hex color -> integer
+                }],
+            };
+
+            await sendWebhookPayload(req, webhookType, body);
+        } catch (e) {
+            req.log.error(`DiscordWebhook.sendNewUserAlert: Error sending new user alert: ${e}`);
+        }
     };
 }


### PR DESCRIPTION
Adds user count to user alert. In order to keep the flow of the discord webhook non-blocking, I chose to pass the user collection to the webhook method, instead of awaiting the number of users query in the response logic. Also wrapped the whole alert method in a try-catch to ensure that a failing webhook will not cause the endpoint to fail.