### PR TITLE
Increase default maxResults for replays endpoint

### DIFF
--- a/app/lib/api/apiRequests.ts
+++ b/app/lib/api/apiRequests.ts
@@ -39,7 +39,7 @@ const DEFAULT_FILTERS = {
     endRaceTimeMax: -1,
     raceFinished: -1,
     dateMin: new Date(),
-    maxResults: 1000,
+    maxResults: 10000,
     orderBy: 'None',
 };
 


### PR DESCRIPTION
Increases default `maxResults` parameter for /replays endpoint calls from `1000` to `10000`. 

In the future, this should be fixed by implementing actual pagination in the replay table, instead of increasing the `maxResults` parameter.