### PR TITLE
Server changes for sector times

### DIFF
--- a/app/components/maps/SidebarReplays.tsx
+++ b/app/components/maps/SidebarReplays.tsx
@@ -119,10 +119,10 @@ const SidebarReplays = ({
             dataIndex: 'properties',
             align: 'center',
             width: 35,
-            render: (i: number, replay) => (
+            render: (_, replay) => (
                 <>
-                    {Math.random() < 0.1 ? (
-                        <Tooltip title="Replay includes CP/sector times" placement="top">
+                    {replay.sectorTimes ? (
+                        <Tooltip title="Replay includes CP/sector times" placement="right">
                             <ClockCircleOutlined />
                         </Tooltip>
                     ) : null}

--- a/app/components/maps/SidebarReplays.tsx
+++ b/app/components/maps/SidebarReplays.tsx
@@ -3,7 +3,7 @@ import {
     Button, Drawer, message, Popconfirm, Spin, Table, Tooltip,
 } from 'antd';
 import {
-    DeleteOutlined, FilterFilled, QuestionCircleOutlined, ReloadOutlined, UnorderedListOutlined,
+    DeleteOutlined, FilterFilled, QuestionCircleOutlined, ReloadOutlined, UnorderedListOutlined, ClockCircleOutlined,
 } from '@ant-design/icons';
 import { ColumnsType, TablePaginationConfig } from 'antd/lib/table';
 import { ColumnType, TableCurrentDataSource } from 'antd/lib/table/interface';
@@ -112,6 +112,21 @@ const SidebarReplays = ({
                     Filter
                     <FilterFilled />
                 </div>
+            ),
+        },
+        {
+            title: '',
+            dataIndex: 'properties',
+            align: 'center',
+            width: 35,
+            render: (i: number, replay) => (
+                <>
+                    {Math.random() < 0.1 ? (
+                        <Tooltip title="Replay includes CP/sector times" placement="top">
+                            <ClockCircleOutlined />
+                        </Tooltip>
+                    ) : null}
+                </>
             ),
         },
         {

--- a/app/components/maps/SidebarReplays.tsx
+++ b/app/components/maps/SidebarReplays.tsx
@@ -114,9 +114,11 @@ const SidebarReplays = ({
                 </div>
             ),
         },
+        /*
+        Remove sector time indicator column until fully implemented
         {
             title: '',
-            dataIndex: 'properties',
+            dataIndex: 'sectorTime',
             align: 'center',
             width: 35,
             render: (_, replay) => (
@@ -129,6 +131,7 @@ const SidebarReplays = ({
                 </>
             ),
         },
+        */
         {
             title: 'Time',
             dataIndex: 'readableTime',

--- a/app/components/viewer/ReplayLines.tsx
+++ b/app/components/viewer/ReplayLines.tsx
@@ -92,9 +92,13 @@ export const ReplayLines = ({
                 {(replay.dnfPos.x !== 0 && replay.dnfPos.y !== 0 && replay.dnfPos.z !== 0) && (
                     <ReplayDnf key={`replay-${replay._id}-dnf`} replay={replay} />
                 )}
-                {replay.sectorTimes && (
-                    <ReplaySectorHighlights replay={replay} />
-                )}
+
+                {/* Removed until fully implemented: */}
+                {/*
+                    {replay.sectorTimes && (
+                        <ReplaySectorHighlights replay={replay} />
+                    )}
+                */}
             </>
         ))}
     </>

--- a/app/components/viewer/ReplayLines.tsx
+++ b/app/components/viewer/ReplayLines.tsx
@@ -12,6 +12,7 @@ import {
 import ReplayChartHoverLocation from './ReplayChartHoverLocation';
 import ReplayDnf from './ReplayDnf';
 import ReplayGears from './ReplayGears';
+import ReplaySectorHighlights from './ReplaySectorHighlights';
 
 export interface LineType {
     name: string;
@@ -90,6 +91,9 @@ export const ReplayLines = ({
                 )}
                 {(replay.dnfPos.x !== 0 && replay.dnfPos.y !== 0 && replay.dnfPos.z !== 0) && (
                     <ReplayDnf key={`replay-${replay._id}-dnf`} replay={replay} />
+                )}
+                {replay.sectorTimes && (
+                    <ReplaySectorHighlights replay={replay} />
                 )}
             </>
         ))}

--- a/app/components/viewer/ReplaySectorHighlights.tsx
+++ b/app/components/viewer/ReplaySectorHighlights.tsx
@@ -1,0 +1,41 @@
+import React, { useMemo } from 'react';
+import * as THREE from 'three';
+import { Sphere } from '@react-three/drei';
+import { DoubleSide } from 'three';
+import { ReplayData } from '../../lib/api/apiRequests';
+import { getSampleNearTime } from '../../lib/utils/replay';
+
+const SECTOR_INDICATOR_COLOR = new THREE.Color('white');
+
+interface SectorIndicatorProps {
+    position: THREE.Vector3;
+}
+const SectorIndicator = ({ position }: SectorIndicatorProps) => (
+    <Sphere position={position} args={[2]}>
+        <meshBasicMaterial attach="material" side={DoubleSide} color={SECTOR_INDICATOR_COLOR} />
+    </Sphere>
+);
+
+interface ReplaySectorIndicatorProps {
+    replay: ReplayData;
+}
+const ReplaySectorHighlights = ({ replay }: ReplaySectorIndicatorProps): JSX.Element => {
+    const sectorIndicatorPositions = useMemo(() => {
+        const positions = replay.sectorTimes?.map((sectorTime) => {
+            const sample = getSampleNearTime(replay, sectorTime);
+            return sample.position;
+        });
+        return positions;
+    }, [replay]);
+
+    return (
+        <>
+            {sectorIndicatorPositions?.map((pos, i) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <SectorIndicator key={`${replay._id}_${i}`} position={pos} />
+            ))}
+        </>
+    );
+};
+
+export default ReplaySectorHighlights;

--- a/app/lib/api/apiRequests.ts
+++ b/app/lib/api/apiRequests.ts
@@ -14,6 +14,7 @@ interface FilterParams {
 }
 
 export interface FileResponse {
+    sectorTimes?: number[];
     authorName: string;
     mapUId: string;
     date: number;

--- a/server/src/routes/replays.ts
+++ b/server/src/routes/replays.ts
@@ -146,6 +146,32 @@ router.post('/', (req: Request, res: Response, next: Function): any => {
                 userID = updatedUserInfo.userID;
             }
 
+            // parse sector times
+            // convert string of sector times separated by ',' to array of numbers
+            // "1,2,3" -> [1, 2, 3]
+            let sectorTimes = null;
+            if (req.query.sectorTimes && typeof req.query.sectorTimes === 'string') {
+                const sectorTimesList: string[] = (req.query.sectorTimes as string).split(',');
+
+                try {
+                    sectorTimes = sectorTimesList.map((time) => parseInt(time, 10));
+                } catch (e) {
+                    req.log.error(`Could not parse sector times (${req.query.sectorTimes}): ${e}`);
+                }
+
+                // Set sector times to null if they contain NaN values (parseInt returns NaN for non-numeric values)
+                if (sectorTimes.filter((time) => Number.isNaN(time)).length > 0) {
+                    // eslint-disable-next-line max-len
+                    req.log.error(`Could not parse sector times (${req.query.sectorTimes}): ${sectorTimes} contains NaN`);
+                    sectorTimes = null;
+                }
+
+                // Set sector times to null if the list is empty
+                if (sectorTimes && sectorTimes.length === 0) {
+                    sectorTimes = null;
+                }
+            }
+
             const metadata = {
                 // reference map and user docs
                 mapRef: map._id,
@@ -153,6 +179,8 @@ router.post('/', (req: Request, res: Response, next: Function): any => {
                 date: Date.now(),
                 raceFinished: parseInt(`${req.query.raceFinished}`, 10),
                 endRaceTime: parseInt(`${req.query.endRaceTime}`, 10),
+                pluginVersion: req.query.pluginVersion,
+                sectorTimes,
                 ...storedReplay,
             };
             req.log.debug('replaysRouter: Saving replay metadata');


### PR DESCRIPTION
This PR adds the server changes necessary to store the sector times, recorded by the updated plugin: https://github.com/tm-dojo/plugin/pull/14

Changes:

Backend:
- Accept `sectorTimes` query parameter on the `POST /replays` endpoint
- `sectorTimes` is parsed from a joined string ('1,2,3,4,') to an array ([1,2,3,4]), only accepting integers and non-empty arrays
- These sector times are stored alongside the other replay metadata, inside of the DB document

Frontend:
- Some code for placeholder components, once we get to implementing front-end features for sector time analysis