### PR TITLE
Sector Time Delta Table

### DIFF
--- a/app/components/common/SideDrawerExpandButton.tsx
+++ b/app/components/common/SideDrawerExpandButton.tsx
@@ -5,9 +5,12 @@ import React from 'react';
 interface SideDrawerExpandButtonProps {
     onClick: () => void;
     content: JSX.Element;
-    side:'left'|'right';
+    side: 'left' | 'right';
+    includeArrowIcon?: boolean;
 }
-const SideDrawerExpandButton = ({ onClick, content, side }: SideDrawerExpandButtonProps) => (
+const SideDrawerExpandButton = ({
+    onClick, content, side, includeArrowIcon = true,
+}: SideDrawerExpandButtonProps) => (
     <Button
         onClick={onClick}
         className="p-6 flex flex-row items-center"
@@ -23,13 +26,13 @@ const SideDrawerExpandButton = ({ onClick, content, side }: SideDrawerExpandButt
     >
         {side === 'right' ? (
             <>
-                <CaretLeftOutlined className="mr-4" />
+                {includeArrowIcon && <CaretLeftOutlined className="mr-4" />}
                 {content}
             </>
         ) : (
             <>
                 {content}
-                <CaretRightOutlined className="ml-4" />
+                {includeArrowIcon && <CaretRightOutlined className="ml-4" />}
             </>
         )}
     </Button>

--- a/app/components/maps/SectorTimeTableButton.tsx
+++ b/app/components/maps/SectorTimeTableButton.tsx
@@ -1,0 +1,24 @@
+import { ClockCircleOutlined } from '@ant-design/icons';
+import React from 'react';
+import SideDrawerExpandButton from '../common/SideDrawerExpandButton';
+
+interface Props {
+    onClick: () => void;
+}
+const SectorTimeTableButton = ({ onClick }: Props) => (
+    <div className="absolute mt-36 z-10">
+        <SideDrawerExpandButton
+            side="left"
+            includeArrowIcon={false}
+            content={(
+                <>
+                    <ClockCircleOutlined className="mr-2" />
+                    Sector Time Table
+                </>
+            )}
+            onClick={() => onClick()}
+        />
+    </div>
+);
+
+export default SectorTimeTableButton;

--- a/app/components/maps/SectorTimeTableButton.tsx
+++ b/app/components/maps/SectorTimeTableButton.tsx
@@ -16,7 +16,7 @@ const SectorTimeTableButton = ({ onClick }: Props) => (
                     Sector Time Table
                 </>
             )}
-            onClick={() => onClick()}
+            onClick={onClick}
         />
     </div>
 );

--- a/app/components/maps/SectorTimeTableModal.tsx
+++ b/app/components/maps/SectorTimeTableModal.tsx
@@ -238,8 +238,7 @@ const SectorTimeTableModal = ({ visible, setVisible, replays }: Props): JSX.Elem
             )}
             centered
             visible={visible}
-            onOk={() => setVisible(false)}
-            onCancel={() => setVisible(false)}
+            footer={null}
             width="80%"
             bodyStyle={{
                 overflow: 'auto', margin: 0, padding: 0, paddingLeft: '16px',

--- a/app/components/maps/SectorTimeTableModal.tsx
+++ b/app/components/maps/SectorTimeTableModal.tsx
@@ -164,10 +164,17 @@ const SectorTimeTableModal = ({ visible, setVisible, replays }: Props): JSX.Elem
                             ? getRaceTimeStr(sectorTime)
                             : `${timeDiff <= 0 ? '-' : '+'}${getRaceTimeStr(Math.abs(timeDiff))}`;
 
+                        // Generate hover tooltip title
+                        const tooltipTitle = getRaceTimeStr(sectorTime);
+
                         return (
-                            <code style={{ color }}>
-                                {timeStr}
-                            </code>
+                            <Tooltip title={tooltipTitle} placement="topLeft" className="w-full">
+                                <div className="w-full cursor-default">
+                                    <code style={{ color }}>
+                                        {timeStr}
+                                    </code>
+                                </div>
+                            </Tooltip>
                         );
                     },
                 })),

--- a/app/components/maps/SectorTimeTableModal.tsx
+++ b/app/components/maps/SectorTimeTableModal.tsx
@@ -1,0 +1,223 @@
+import React, { useMemo } from 'react';
+import {
+    Button, Empty, Modal, Table,
+} from 'antd';
+import { ColumnsType } from 'antd/lib/table';
+import { ClockCircleOutlined, InfoCircleOutlined, QuestionOutlined } from '@ant-design/icons';
+import { FileResponse } from '../../lib/api/apiRequests';
+import { calcFastestSectorIndices, calcIndividualSectorTimes } from '../../lib/replays/sectorTimes';
+import { getRaceTimeStr, timeDifference } from '../../lib/utils/time';
+
+const openInfoModal = () => {
+    Modal.info({
+        title: 'CP/Sector Time Table Information',
+        content: (
+            <div>
+                {'To view sector time deltas, you need to select at least 1 replay that includes sector times. '}
+                {'Replays with sector times are indicated by the  '}
+                <ClockCircleOutlined />
+                {'  icon in the replay list.'}
+                <br />
+                <br />
+                White: Default color
+                <br />
+                <span style={{ color: 'red' }}>Red: </span>
+                Sector time slower than sector time of fastest time
+                <br />
+                <span style={{ color: 'green' }}>Green: </span>
+                Sector time faster than sector time of fastest time
+                <br />
+                <span style={{ color: '#ae28ca' }}>Purple: </span>
+                Sector time fastest of all replays in that sector
+            </div>
+        ),
+        width: '25%',
+    });
+};
+
+interface Props {
+    visible: boolean;
+    setVisible: (visible: boolean) => void;
+    replays: FileResponse[];
+}
+
+const SectorTimeTableModal = ({ visible, setVisible, replays }: Props): JSX.Element => {
+    const filteredReplays = useMemo(() => replays
+        .filter((replay) => replay.raceFinished
+            && replay.sectorTimes
+            && replay.sectorTimes?.length > 0)
+        .sort((a, b) => a.endRaceTime - b.endRaceTime), [replays]);
+
+    const allIndividualSectorTimes = useMemo(
+        () => filteredReplays.map((replay) => calcIndividualSectorTimes(replay.sectorTimes!, replay.endRaceTime)),
+        [filteredReplays],
+    );
+    const fastestSectorIndices = useMemo(
+        () => calcFastestSectorIndices(allIndividualSectorTimes),
+        [allIndividualSectorTimes],
+    );
+
+    interface Entry {
+        date: string;
+        player: string;
+        time: string;
+        gap: string;
+        // all sector time columns excluded
+    }
+    const columns = useMemo(() => {
+        const generatedColumns: ColumnsType<Entry> = [
+            {
+                title: 'Date',
+                dataIndex: 'date',
+                key: 'date',
+                fixed: 'left',
+                width: 150,
+            },
+            {
+                title: 'Player',
+                dataIndex: 'player',
+                key: 'player',
+                fixed: 'left',
+                width: 150,
+            },
+            {
+                title: 'Time',
+                dataIndex: 'time',
+                key: 'time',
+                fixed: 'left',
+                width: 125,
+                render: (text) => (<code>{text}</code>),
+            },
+            {
+                title: 'Gap',
+                dataIndex: 'gap',
+                key: 'gap',
+                fixed: 'left',
+                width: 125,
+                render: (text) => (<code>{text}</code>),
+            },
+        ];
+
+        if (filteredReplays.length > 0 && filteredReplays[0].sectorTimes) {
+            const numSectors = filteredReplays[0].sectorTimes.length;
+            for (let i = 0; i < numSectors + 1; i++) {
+                generatedColumns.push({
+                    title: `S${i + 1}`,
+                    dataIndex: `sector${i + 1}`,
+                    key: `sector${i + 1}`,
+                    render: (text, _, replayIndex) => {
+                        let color = '';
+                        if (fastestSectorIndices && fastestSectorIndices[i] === replayIndex) {
+                            // fastest sector: purple
+                            color = '#ae28ca';
+                        } else if (replayIndex > 0) {
+                            // delta positive/negative: red/green
+                            color = text.includes('+') ? 'red' : 'green';
+                        }
+
+                        return (
+                            <code style={{ color }}>
+                                {text}
+                            </code>
+                        );
+
+                        // Placeholder for when absolute time toggle is implemented:
+                        // return (
+                        //     <code style={{ color }}>
+                        //         {getRaceTimeStr(allIndividualSectorTimes[replayIndex][i])}
+                        //     </code>
+                        // );
+                    },
+                });
+            }
+        }
+        return generatedColumns;
+    }, [fastestSectorIndices, filteredReplays]);
+
+    const dataSource = useMemo(() => {
+        if (filteredReplays.length === 0) {
+            return [];
+        }
+
+        // Get reference finish time from the first replay in the filteredReplays list
+        const referenceFinishTime = filteredReplays[0].endRaceTime;
+
+        const data: Entry[] = filteredReplays.map((replay, replayIndex) => {
+            const entry: any = {};
+
+            const now = new Date().getTime();
+            entry.date = timeDifference(now, replay.date);
+            entry.player = replay.playerName;
+            entry.time = getRaceTimeStr(replay.endRaceTime);
+
+            // Set gap time of first replay to '-', and to '+gap' for all other replays
+            entry.gap = replayIndex === 0
+                ? '-'
+                : `+${getRaceTimeStr(replay.endRaceTime - referenceFinishTime)}`;
+
+            // Set all sector times
+            const individualSectorTimes = allIndividualSectorTimes[replayIndex];
+            if (individualSectorTimes) {
+                for (let i = 0; i < individualSectorTimes.length; i++) {
+                    const individualSectorTime = individualSectorTimes[i];
+                    if (replayIndex === 0) {
+                        // First replay: always display the absolute sector time
+                        entry[`sector${i + 1}`] = getRaceTimeStr(individualSectorTime);
+                    } else {
+                        // Other replays: display the delta to the sectors of the fastest replay
+                        const referenceTime = allIndividualSectorTimes[0][i];
+
+                        const timeDiff = individualSectorTime - referenceTime;
+                        const sign = timeDiff < 0 ? '-' : '+';
+
+                        entry[`sector${i + 1}`] = `${sign}${getRaceTimeStr(Math.abs(timeDiff))}`;
+                    }
+                }
+            }
+
+            return entry;
+        });
+        return data;
+    }, [allIndividualSectorTimes, filteredReplays]);
+
+    return (
+        <Modal
+            title={(
+                <div className="flex gap-4 items-center">
+                    CP/Sector Time Table
+                    <Button
+                        onClick={openInfoModal}
+                        shape="circle"
+                        icon={<QuestionOutlined />}
+                    />
+                </div>
+            )}
+            centered
+            visible={visible}
+            onOk={() => setVisible(false)}
+            onCancel={() => setVisible(false)}
+            width="80%"
+            bodyStyle={{
+                overflow: 'auto', margin: 0, padding: 0, paddingLeft: '16px',
+            }}
+        >
+            {dataSource.length === 0 ? (
+                <Empty
+                    className="h-20"
+                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                    description="No data to display. Select one or more replays with sector times."
+                />
+            ) : (
+                <Table
+                    columns={columns}
+                    dataSource={dataSource}
+                    pagination={false}
+                    size="small"
+                    scroll={{ x: true }}
+                />
+            )}
+        </Modal>
+    );
+};
+
+export default SectorTimeTableModal;

--- a/app/components/maps/SectorTimeTableModal.tsx
+++ b/app/components/maps/SectorTimeTableModal.tsx
@@ -239,6 +239,8 @@ const SectorTimeTableModal = ({ visible, setVisible, replays }: Props): JSX.Elem
             centered
             visible={visible}
             footer={null}
+            onOk={() => setVisible(false)}
+            onCancel={() => setVisible(false)}
             width="80%"
             bodyStyle={{
                 overflow: 'auto', margin: 0, padding: 0, paddingLeft: '16px',

--- a/app/components/maps/SectorTimeTableModal.tsx
+++ b/app/components/maps/SectorTimeTableModal.tsx
@@ -254,6 +254,7 @@ const SectorTimeTableModal = ({ visible, setVisible, replays }: Props): JSX.Elem
             onOk={() => setVisible(false)}
             onCancel={() => setVisible(false)}
             width="80%"
+            zIndex={1001} // 1000 is default for Drawer components
             style={{
                 maxHeight: '80%',
             }}

--- a/app/components/maps/SectorTimeTableModal.tsx
+++ b/app/components/maps/SectorTimeTableModal.tsx
@@ -112,7 +112,7 @@ const SectorTimeTableModal = ({ visible, setVisible, replays }: Props): JSX.Elem
         },
         {
             title: 'Sector Times',
-            children: ((filteredReplays[0] && filteredReplays[0].sectorTimes) || []).map((_, sectorIndex) => ({
+            children: (allIndividualSectorTimes[0] || []).map((_, sectorIndex) => ({
                 title: `S${sectorIndex + 1}`,
                 dataIndex: `sectorTimes[${sectorIndex}]`,
                 key: `sectorTimes[${sectorIndex}]`,

--- a/app/components/maps/SectorTimeTableModal.tsx
+++ b/app/components/maps/SectorTimeTableModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import {
     Button, Empty, Modal, Table,
 } from 'antd';
@@ -79,7 +79,7 @@ const SectorTimeTableModal = ({ visible, setVisible, replays }: Props): JSX.Elem
                 dataIndex: 'date',
                 key: 'date',
                 fixed: 'left',
-                width: 150,
+                width: 200,
                 render: (_, entry) => (
                     entry.date
                         ? timeDifference(new Date().getTime(), entry.date)
@@ -99,11 +99,6 @@ const SectorTimeTableModal = ({ visible, setVisible, replays }: Props): JSX.Elem
                 key: 'time',
                 fixed: 'left',
                 width: 125,
-                onCell: (entry) => ({
-                    style: {
-                        backgroundColor: entry.isTheoreticalBest ? 'black' : undefined,
-                    },
-                }),
                 render: (_, entry) => (
                     <code>
                         {getRaceTimeStr(entry.time)}
@@ -131,7 +126,7 @@ const SectorTimeTableModal = ({ visible, setVisible, replays }: Props): JSX.Elem
                     title: `S${sectorIndex + 1}`,
                     dataIndex: `sectorTimes[${sectorIndex}]`,
                     key: `sectorTimes[${sectorIndex}]`,
-                    width: 100,
+                    width: 75,
                     render: (_1, entry) => {
                         // Get different times
                         const sectorTime = entry.sectorTimes[sectorIndex];
@@ -242,8 +237,14 @@ const SectorTimeTableModal = ({ visible, setVisible, replays }: Props): JSX.Elem
             onOk={() => setVisible(false)}
             onCancel={() => setVisible(false)}
             width="80%"
+            style={{
+                maxHeight: '80%',
+            }}
             bodyStyle={{
-                overflow: 'auto', margin: 0, padding: 0, paddingLeft: '16px',
+                overflow: 'auto',
+                margin: 0,
+                padding: 0,
+                paddingLeft: '16px',
             }}
         >
             {dataSource.length === 0 ? (
@@ -263,7 +264,7 @@ const SectorTimeTableModal = ({ visible, setVisible, replays }: Props): JSX.Elem
                     })}
                     pagination={false}
                     size="small"
-                    scroll={{ x: true }}
+                    scroll={{ x: true, y: '50vh' }}
                 />
             )}
         </Modal>

--- a/app/components/maps/SectorTimeTableModal.tsx
+++ b/app/components/maps/SectorTimeTableModal.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import {
-    Button, Empty, Modal, Table,
+    Button, Empty, Modal, Table, Tooltip,
 } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { ClockCircleOutlined, QuestionOutlined } from '@ant-design/icons';
@@ -123,7 +123,24 @@ const SectorTimeTableModal = ({ visible, setVisible, replays }: Props): JSX.Elem
             {
                 title: 'Sector Times',
                 children: (allIndividualSectorTimes[0] || []).map((_, sectorIndex) => ({
-                    title: `S${sectorIndex + 1}`,
+                    title: () => {
+                        const sectorStart = sectorIndex === 0
+                            ? 'Start'
+                            : `CP ${sectorIndex}`;
+                        const sectorEnd = sectorIndex === allIndividualSectorTimes[0].length - 1
+                            ? 'Finish'
+                            : `CP ${sectorIndex + 1}`;
+
+                        const title = `${sectorStart} ➞ ${sectorEnd}`;
+
+                        return (
+                            <Tooltip title={title} className="w-full">
+                                <div className="w-full cursor-default text-center">
+                                    {`S${sectorIndex + 1}`}
+                                </div>
+                            </Tooltip>
+                        );
+                    },
                     dataIndex: `sectorTimes[${sectorIndex}]`,
                     key: `sectorTimes[${sectorIndex}]`,
                     width: 75,

--- a/app/components/maps/SidebarReplays.tsx
+++ b/app/components/maps/SidebarReplays.tsx
@@ -1,9 +1,16 @@
 import React, { useState, useEffect, useContext } from 'react';
 import {
-    Button, Drawer, message, Popconfirm, Spin, Table, Tooltip,
+    Button, Drawer, Dropdown, Menu, message, Popconfirm, Space, Spin, Table, Tooltip,
 } from 'antd';
 import {
-    DeleteOutlined, FilterFilled, QuestionCircleOutlined, ReloadOutlined, UnorderedListOutlined, ClockCircleOutlined,
+    DeleteOutlined,
+    FilterFilled,
+    QuestionCircleOutlined,
+    ReloadOutlined, UnorderedListOutlined,
+    ClockCircleOutlined,
+    DownOutlined,
+    TrophyFilled,
+    ClockCircleFilled,
 } from '@ant-design/icons';
 import { ColumnsType, TablePaginationConfig } from 'antd/lib/table';
 import { ColumnType, TableCurrentDataSource } from 'antd/lib/table/interface';
@@ -110,6 +117,19 @@ const SidebarReplays = ({
             replayIndices.map((index) => filteredReplays[index]),
             selectedReplayDataIds,
         );
+    };
+
+    const onLoadFastestTime = () => {
+        // Filter finished replays and sort by time
+        const filteredReplays = replays
+            .filter((replay) => replay.raceFinished)
+            .sort((a, b) => a.endRaceTime - b.endRaceTime);
+
+        if (filteredReplays.length === 0) {
+            return;
+        }
+
+        onLoadReplay(filteredReplays[0]);
     };
 
     // TODO: add useMemo to filters and columns
@@ -314,22 +334,50 @@ const SidebarReplays = ({
                 <Spin spinning={loadingReplays}>
                     <div className="flex flex-row justify-between items-center mb-3 mx-4">
                         <div className="flex flex-row gap-4">
+                            {/* Load current page */}
                             <CleanButton
                                 onClick={() => onLoadAllVisibleReplays(visibleReplays, selectedReplayDataIds)}
                             >
-                                Load all visible
+                                Load page
                             </CleanButton>
+
+                            {/* Load other dropdown */}
+                            <Dropdown overlay={(
+                                <Menu>
+                                    <Menu.Item
+                                        className="text-md"
+                                        icon={<TrophyFilled />}
+                                        onClick={() => onLoadFastestTime()}
+                                    >
+                                        Fastest Time
+                                    </Menu.Item>
+                                    <Menu.Item
+                                        className="text-md"
+                                        icon={<ClockCircleFilled />}
+                                        onClick={() => onLoadReplaysWithFastestSectorTimes()}
+                                    >
+                                        All replays containing fastest sectors
+                                    </Menu.Item>
+                                </Menu>
+                            )}
+                            >
+                                <Space className="cursor-pointer">
+                                    <CleanButton
+                                        onClick={() => { }}
+                                        backColor="gray"
+                                    >
+                                        Load other...
+                                        <DownOutlined />
+                                    </CleanButton>
+                                </Space>
+                            </Dropdown>
+
+                            {/* Unload all */}
                             <CleanButton
                                 onClick={() => onRemoveAllReplays(visibleReplays)}
                                 backColor="#B41616"
                             >
                                 Unload all
-                            </CleanButton>
-                            <CleanButton
-                                onClick={() => onLoadReplaysWithFastestSectorTimes()}
-                                backColor="#ae28ca"
-                            >
-                                Load Replays with Fastest Sectors
                             </CleanButton>
                         </div>
                         <div className="mr-6">

--- a/app/components/maps/SidebarReplays.tsx
+++ b/app/components/maps/SidebarReplays.tsx
@@ -114,24 +114,23 @@ const SidebarReplays = ({
                 </div>
             ),
         },
-        /*
-        Remove sector time indicator column until fully implemented
         {
-            title: '',
+            title: 'Sectors',
             dataIndex: 'sectorTime',
             align: 'center',
-            width: 35,
+            width: 30,
+            filters: [{ text: 'Includes sector times', value: true }],
+            onFilter: (value, record) => !!record.sectorTimes === value,
             render: (_, replay) => (
                 <>
-                    {replay.sectorTimes ? (
+                    {replay.sectorTimes && (
                         <Tooltip title="Replay includes CP/sector times" placement="right">
                             <ClockCircleOutlined />
                         </Tooltip>
-                    ) : null}
+                    )}
                 </>
             ),
         },
-        */
         {
             title: 'Time',
             dataIndex: 'readableTime',

--- a/app/components/viewer/ReplaySectorHighlights.tsx
+++ b/app/components/viewer/ReplaySectorHighlights.tsx
@@ -4,15 +4,17 @@ import { Sphere } from '@react-three/drei';
 import { DoubleSide } from 'three';
 import { ReplayData } from '../../lib/api/apiRequests';
 import { getSampleNearTime } from '../../lib/utils/replay';
+import { setInterpolatedVector } from '../../lib/utils/math';
 
 const SECTOR_INDICATOR_COLOR = new THREE.Color('white');
 
 interface SectorIndicatorProps {
     position: THREE.Vector3;
+    color?: THREE.Color;
 }
-const SectorIndicator = ({ position }: SectorIndicatorProps) => (
+const SectorIndicator = ({ position, color }: SectorIndicatorProps) => (
     <Sphere position={position} args={[2]}>
-        <meshBasicMaterial attach="material" side={DoubleSide} color={SECTOR_INDICATOR_COLOR} />
+        <meshBasicMaterial attach="material" side={DoubleSide} color={color || SECTOR_INDICATOR_COLOR} />
     </Sphere>
 );
 
@@ -20,10 +22,35 @@ interface ReplaySectorIndicatorProps {
     replay: ReplayData;
 }
 const ReplaySectorHighlights = ({ replay }: ReplaySectorIndicatorProps): JSX.Element => {
+    const interpolatedPositions = useMemo(() => {
+        const positions = replay.sectorTimes?.map((sectorTime) => {
+            const sample = getSampleNearTime(replay, sectorTime);
+            const prevSample = replay.samples[replay.samples.indexOf(sample) - 1];
+
+            const factor: number = (sectorTime - prevSample.currentRaceTime)
+                / (sample.currentRaceTime - prevSample.currentRaceTime);
+
+            const interpolatedPosition = new THREE.Vector3();
+            setInterpolatedVector(interpolatedPosition, prevSample.position, sample.position, factor);
+
+            return interpolatedPosition;
+        });
+        return positions;
+    }, [replay]);
+
     const sectorIndicatorPositions = useMemo(() => {
         const positions = replay.sectorTimes?.map((sectorTime) => {
             const sample = getSampleNearTime(replay, sectorTime);
             return sample.position;
+        });
+        return positions;
+    }, [replay]);
+
+    const prevIndicatorPositions = useMemo(() => {
+        const positions = replay.sectorTimes?.map((sectorTime) => {
+            const sample = getSampleNearTime(replay, sectorTime);
+            const prevSample = replay.samples[replay.samples.indexOf(sample) - 1];
+            return prevSample.position;
         });
         return positions;
     }, [replay]);
@@ -33,6 +60,14 @@ const ReplaySectorHighlights = ({ replay }: ReplaySectorIndicatorProps): JSX.Ele
             {sectorIndicatorPositions?.map((pos, i) => (
                 // eslint-disable-next-line react/no-array-index-key
                 <SectorIndicator key={`${replay._id}_${i}`} position={pos} />
+            ))}
+            {interpolatedPositions?.map((pos, i) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <SectorIndicator key={`${replay._id}_${i}`} position={pos} color={new THREE.Color(1, 0, 0)} />
+            ))}
+            {prevIndicatorPositions?.map((pos, i) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <SectorIndicator key={`${replay._id}_${i}`} position={pos} color={new THREE.Color(0, 1, 0)} />
             ))}
         </>
     );

--- a/app/lib/replays/sectorTimes.ts
+++ b/app/lib/replays/sectorTimes.ts
@@ -1,0 +1,52 @@
+export const calcIndividualSectorTimes = (sectorTimes: number[], endRaceTime: number): number[] => {
+    const individualSectorTimes: number[] = [];
+
+    // Calculate sector differences based on the previous sector times
+    sectorTimes.forEach((sectorTime, i) => {
+        if (i === 0) {
+            // Don't calculate the difference for the first sector
+            individualSectorTimes.push(sectorTime);
+        } else {
+            // Calculate sector time as difference between this and previous sector
+            individualSectorTimes.push(sectorTime - sectorTimes[i - 1]);
+        }
+    });
+
+    // Add last sector, from last CP to the finish
+    individualSectorTimes.push(endRaceTime - sectorTimes[sectorTimes.length - 1]);
+
+    return individualSectorTimes;
+};
+
+/**
+ * Calculate the index of the fastest sector time for all replays
+ * @param individualSectorTimes - 2D array of sector times for each replay
+ *      Index order should be: individualSectorTimes[replayIndex][sectorIndex]
+ * @returns array of indices of the replay that had the fastest sector time
+ */
+export const calcFastestSectorIndices = (individualSectorTimes: number[][]): number[] => {
+    if (individualSectorTimes.length === 0) {
+        return [];
+    }
+
+    const numSectors = individualSectorTimes[0].length;
+
+    // Initialize fastestSectors
+    const fastestSectors: number[] = new Array(numSectors);
+    for (let sectorIndex = 0; sectorIndex < numSectors; sectorIndex++) {
+        // Initialize fastestSectorTimes of each sector with replay 0
+        fastestSectors[sectorIndex] = 0;
+        let fastestSectorTime = individualSectorTimes[0][sectorIndex];
+
+        // For each replay, check whether the sector time is faster than the current fastest
+        for (let replayIndex = 1; replayIndex < individualSectorTimes.length; replayIndex++) {
+            const sectorTime = individualSectorTimes[replayIndex][sectorIndex];
+            if (sectorTime < fastestSectorTime) {
+                // If replay sector time is faster, update fastest sector time and index
+                fastestSectorTime = sectorTime;
+                fastestSectors[sectorIndex] = replayIndex;
+            }
+        }
+    }
+    return fastestSectors;
+};

--- a/app/lib/utils/time.ts
+++ b/app/lib/utils/time.ts
@@ -1,11 +1,15 @@
 export const getRaceTimeStr = (raceTime: number): string => {
-    const milliseconds = raceTime % 1000;
-    const seconds = Math.floor((raceTime / 1000) % 60);
-    const minutes = Math.floor((raceTime / (60 * 1000)) % 60);
-    const hours = Math.floor((raceTime / (60 * 60 * 1000)) % 60);
+    const sign = raceTime < 0 ? '-' : '';
+    const absRaceTime = Math.abs(raceTime);
+
+    const milliseconds = absRaceTime % 1000;
+    const seconds = Math.floor((absRaceTime / 1000) % 60);
+    const minutes = Math.floor((absRaceTime / (60 * 1000)) % 60);
+    const hours = Math.floor((absRaceTime / (60 * 60 * 1000)) % 60);
 
     return (
-        `${`${hours > 0 ? `${hours}:` : ''}`
+        `${sign}`
+        + `${`${hours > 0 ? `${hours}:` : ''}`
         + `${minutes > 0 ? `${hours > 0 ? String(minutes).padStart(2, '0') : minutes}:` : ''}`
         + `${minutes > 0 ? String(seconds).padStart(2, '0') : seconds}`
         + '.'}${String(milliseconds).padStart(3, '0')}`

--- a/app/pages/maps/[mapUId]/index.tsx
+++ b/app/pages/maps/[mapUId]/index.tsx
@@ -80,6 +80,9 @@ const Home = (): JSX.Element => {
     }, [mapUId]);
 
     const onLoadReplay = async (replay: FileResponse) => {
+        if (selectedReplayData.some((r) => r._id === replay._id)) {
+            return;
+        }
         const replayData = await fetchReplayData(replay);
         setSelectedReplayData([...selectedReplayData, replayData]);
     };

--- a/app/pages/maps/[mapUId]/index.tsx
+++ b/app/pages/maps/[mapUId]/index.tsx
@@ -7,6 +7,7 @@ import dayjs from 'dayjs';
 import SidebarReplays from '../../../components/maps/SidebarReplays';
 import SidebarSettings from '../../../components/maps/SidebarSettings';
 import MapHeader from '../../../components/maps/MapHeader';
+import SectorTimeTableModal from '../../../components/maps/SectorTimeTableModal';
 import Viewer3D from '../../../components/viewer/Viewer3D';
 import {
     getReplays,
@@ -22,12 +23,14 @@ import { cleanTMFormatting } from '../../../lib/utils/formatting';
 import LoadedReplays from '../../../components/maps/LoadedReplays';
 import CleanButton from '../../../components/common/CleanButton';
 import useIsMobileDevice from '../../../lib/hooks/useIsMobileDevice';
+import SectorTimeTableButton from '../../../components/maps/SectorTimeTableButton';
 
 const Home = (): JSX.Element => {
     const [replays, setReplays] = useState<FileResponse[]>([]);
     const [loadingReplays, setLoadingReplays] = useState<boolean>(true);
     const [selectedReplayData, setSelectedReplayData] = useState<ReplayData[]>([]);
     const [mapData, setMapData] = useState<MapInfo>({});
+    const [sectorTableVisible, setSectorTableVisible] = useState<boolean>(false);
 
     const router = useRouter();
     const { mapUId } = router.query;
@@ -124,6 +127,13 @@ const Home = (): JSX.Element => {
                         </div>
                     </CleanButton>
                 </MapHeader>
+
+                <SectorTimeTableModal
+                    replays={selectedReplayData}
+                    visible={sectorTableVisible}
+                    setVisible={setSectorTableVisible}
+                />
+
                 <Layout.Content>
                     <SidebarReplays
                         mapUId={`${mapUId}`}
@@ -136,19 +146,22 @@ const Home = (): JSX.Element => {
                         selectedReplayDataIds={selectedReplayData.map((replay) => replay._id)}
                         onRefreshReplays={fetchAndSetReplays}
                     />
-                    {
-                        selectedReplayData.length > 0
-                        && <LoadedReplays replays={selectedReplayData} />
-                    }
+
+                    {selectedReplayData.length > 0
+                        && <LoadedReplays replays={selectedReplayData} />}
+
                     <SidebarSettings />
-                    {
-                        selectedReplayData.length > 0
-                        && (
-                            <ChartsDrawer
-                                replaysData={selectedReplayData}
-                            />
-                        )
-                    }
+
+                    <SectorTimeTableButton
+                        onClick={() => setSectorTableVisible(!sectorTableVisible)}
+                    />
+
+                    {selectedReplayData.length > 0 && (
+                        <ChartsDrawer
+                            replaysData={selectedReplayData}
+                        />
+                    )}
+
                     <Viewer3D
                         replaysData={selectedReplayData}
                     />


### PR DESCRIPTION
### Adds sector delta table to compare sector times between runs:
![image](https://user-images.githubusercontent.com/22432233/166118700-1e3d8275-1fa3-40f5-bac0-cc8ee2292bbb.png)

- Table displaying date, player name, time, gap to fastest time, and sector deltas to sector times of fastest time
  - All deltas are calculated in relation to the fastest, currently selected, replay time
- Color coding for sector times:
  - White: default color
  - Red: Sector is slower than that sector in the fastest replay
  - Green: Sector is slower than that sector in the fastest replay
  - Purple: Sector is fastest in that sector of all selected replays
- Theoretical best estimation: 
  - Take the fastest sector times from all replays on all sectors, combine these sectors to create a new theoretical best run of these fastest sectors.

### Adds sector time column:
![image](https://user-images.githubusercontent.com/22432233/166118749-7ab4889c-f3dc-43ff-ab5b-c5d9c2ca86cb.png)

- This column displays whether a run has recorded sector times or not. This is not recorded on all runs, as this requires the latest version + a dependency plugin. Therefore this column was added, including a filter to filter replays that contain this data.

### Introduces "Load other..." dropdown button:
![image](https://user-images.githubusercontent.com/22432233/166118760-aafa200c-9d16-4002-93de-c19e88c8ac77.png)

- Adds a dropdown button containing the following options:
  - "Fastest time": Loads the fastest time stored on TMDojo for this map
  - "Your PB": Loads the currently logged-in users' fastest time. (Button disabled if user is not logged in, or if the user did not drive a replay on this map)
  - "All replays containing fastest sectors": This finds all replays that have a sector time that is fastest of all replays, and loads all replays that have at least one of those sectors. This can be used to easily get the theoretical best time. (Button disabled if there are no replays with sector time data)