### PR TITLE
Sector table fixes

### DIFF
--- a/app/components/maps/SectorTimeTableModal.tsx
+++ b/app/components/maps/SectorTimeTableModal.tsx
@@ -42,6 +42,7 @@ const openInfoModal = () => {
             </div>
         ),
         width: '25%',
+        zIndex: 1020,
     });
 };
 
@@ -268,7 +269,7 @@ const SectorTimeTableModal = ({
             onOk={() => setVisible(false)}
             onCancel={() => setVisible(false)}
             width="80%"
-            zIndex={1001} // 1000 is default for Drawer components
+            zIndex={1010} // 1000 is default for Drawer components
             style={{
                 maxHeight: '80%',
             }}

--- a/app/components/maps/SectorTimeTableModal.tsx
+++ b/app/components/maps/SectorTimeTableModal.tsx
@@ -5,7 +5,11 @@ import {
 import { ColumnsType } from 'antd/lib/table';
 import { ClockCircleOutlined, QuestionOutlined } from '@ant-design/icons';
 import { FileResponse } from '../../lib/api/apiRequests';
-import { calcFastestSectorIndices, calcIndividualSectorTimes } from '../../lib/replays/sectorTimes';
+import {
+    calcFastestSectorIndices,
+    calcIndividualSectorTimes,
+    filterReplaysWithValidSectorTimes,
+} from '../../lib/replays/sectorTimes';
 import { getRaceTimeStr, timeDifference } from '../../lib/utils/time';
 
 const PURPLE_SECTOR_COLOR = '#ae28ca';
@@ -44,15 +48,18 @@ const openInfoModal = () => {
 interface Props {
     visible: boolean;
     setVisible: (visible: boolean) => void;
-    replays: FileResponse[];
+    selectedReplays: FileResponse[];
+    allReplays: FileResponse[];
 }
 
-const SectorTimeTableModal = ({ visible, setVisible, replays }: Props): JSX.Element => {
-    const filteredReplays = useMemo(() => replays
-        .filter((replay) => replay.raceFinished
-            && replay.sectorTimes
-            && replay.sectorTimes?.length > 0)
-        .sort((a, b) => a.endRaceTime - b.endRaceTime), [replays]);
+const SectorTimeTableModal = ({
+    visible, setVisible, selectedReplays, allReplays,
+}: Props): JSX.Element => {
+    const filteredReplays = useMemo(
+        () => filterReplaysWithValidSectorTimes(selectedReplays, allReplays)
+            .sort((a, b) => a.endRaceTime - b.endRaceTime),
+        [allReplays, selectedReplays],
+    );
 
     const allIndividualSectorTimes = useMemo(
         () => filteredReplays.map((replay) => calcIndividualSectorTimes(replay.sectorTimes!, replay.endRaceTime)),

--- a/app/lib/replays/sectorTimes.ts
+++ b/app/lib/replays/sectorTimes.ts
@@ -1,3 +1,5 @@
+import { FileResponse } from '../api/apiRequests';
+
 export const calcIndividualSectorTimes = (sectorTimes: number[], endRaceTime: number): number[] => {
     const individualSectorTimes: number[] = [];
 
@@ -11,7 +13,6 @@ export const calcIndividualSectorTimes = (sectorTimes: number[], endRaceTime: nu
             individualSectorTimes.push(sectorTime - sectorTimes[i - 1]);
         }
     });
-
     // Add last sector, from last CP to the finish
     individualSectorTimes.push(endRaceTime - sectorTimes[sectorTimes.length - 1]);
 
@@ -48,5 +49,43 @@ export const calcFastestSectorIndices = (individualSectorTimes: number[][]): num
             }
         }
     }
+
     return fastestSectors;
+};
+
+export const calcValidSectorsLength = (replays: FileResponse[]): number => {
+    // Filter out replays that don't have sector times
+    const replaysWithSectorTimes = replays
+        .filter((replay) => replay.sectorTimes && replay.sectorTimes.length > 0 && replay.raceFinished);
+
+    // Get max num sectors from all replays
+    const maxNumSectors = Math.max(...replaysWithSectorTimes.map((replay) => replay.sectorTimes!.length));
+
+    return maxNumSectors;
+};
+
+/**
+ * Filters a list of replays on sector time validity.
+ * Uses the max number of sectors on all replays to filter replays that do not have enough sectors.
+ * Using on a complete list of replays to find the max number of stored sectors.
+ *
+ * This should be used to filter replays that have faulty recordings, and do not contain enough sector times.
+ *
+ * @param replaysToFilter - List of replays to filter from
+ * @param allReplays List of all replays, used to find the max number of sectors
+ *
+ * @returns List of replays with valid sector times
+ */
+export const filterReplaysWithValidSectorTimes = (
+    replaysToFilter: FileResponse[],
+    allReplays: FileResponse[],
+): FileResponse[] => {
+    // Get max num sectors from all replays
+    const maxNumSectors = calcValidSectorsLength(allReplays);
+
+    // Filter all replays that have less than max num sectors
+    const replaysWithValidSectorTimes = replaysToFilter
+        .filter((replay) => replay.sectorTimes && replay.sectorTimes.length === maxNumSectors && replay.raceFinished);
+
+    return replaysWithValidSectorTimes;
 };

--- a/app/pages/maps/[mapUId]/index.tsx
+++ b/app/pages/maps/[mapUId]/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Layout, Modal } from 'antd';
 import { useRouter } from 'next/router';
 
@@ -24,6 +24,7 @@ import LoadedReplays from '../../../components/maps/LoadedReplays';
 import CleanButton from '../../../components/common/CleanButton';
 import useIsMobileDevice from '../../../lib/hooks/useIsMobileDevice';
 import SectorTimeTableButton from '../../../components/maps/SectorTimeTableButton';
+import { filterReplaysWithValidSectorTimes } from '../../../lib/replays/sectorTimes';
 
 const Home = (): JSX.Element => {
     const [replays, setReplays] = useState<FileResponse[]>([]);
@@ -36,6 +37,11 @@ const Home = (): JSX.Element => {
     const { mapUId } = router.query;
 
     const isMobile = useIsMobileDevice();
+
+    const selectedReplaysWithValidSectors = useMemo(
+        () => filterReplaysWithValidSectorTimes(selectedReplayData, replays),
+        [selectedReplayData, replays],
+    );
 
     useEffect(() => {
         const shownMobileWarning = localStorage.getItem('mobileViewerWarningShown') !== null;
@@ -132,7 +138,8 @@ const Home = (): JSX.Element => {
                 </MapHeader>
 
                 <SectorTimeTableModal
-                    replays={selectedReplayData}
+                    selectedReplays={selectedReplaysWithValidSectors}
+                    allReplays={replays}
                     visible={sectorTableVisible}
                     setVisible={setSectorTableVisible}
                 />


### PR DESCRIPTION
- Improve the sector time replay filter to exclude replays that have fewer sector times recorded than other replays.
- Increase z index sector time table info modal so it's drawn above the sector time table