### PR TITLE
Customizable replay line trails

### DIFF
--- a/app/components/maps/SidebarSettings.tsx
+++ b/app/components/maps/SidebarSettings.tsx
@@ -1,16 +1,15 @@
 import React, { useContext, useState } from 'react';
-import Title from 'antd/lib/typography/Title';
 import {
-    Button, Checkbox, Drawer, Select, Col, Slider, InputNumber,
+    Checkbox, Drawer, Select, Col, Slider, InputNumber,
 } from 'antd';
 import { CheckboxChangeEvent } from 'antd/lib/checkbox';
-import { CaretLeftOutlined, SettingOutlined } from '@ant-design/icons';
+import { SettingOutlined } from '@ant-design/icons';
+import Text from 'antd/lib/typography/Text';
 import { SettingsContext } from '../../lib/contexts/SettingsContext';
 import { LineTypes } from '../viewer/ReplayLines';
 import SideDrawerExpandButton from '../common/SideDrawerExpandButton';
 import useWindowDimensions from '../../lib/hooks/useWindowDimensions';
 import GlobalTimeLineInfos from '../../lib/singletons/timeLineInfos';
-import Text from 'antd/lib/typography/Text';
 
 const SidebarSettings = (): JSX.Element => {
     const [visible, setVisible] = useState(false);

--- a/app/components/maps/SidebarSettings.tsx
+++ b/app/components/maps/SidebarSettings.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react';
 import Title from 'antd/lib/typography/Title';
 import {
-    Button, Checkbox, Drawer, Select, Col, Slider,
+    Button, Checkbox, Drawer, Select, Col, Slider, InputNumber,
 } from 'antd';
 import { CheckboxChangeEvent } from 'antd/lib/checkbox';
 import { CaretLeftOutlined, SettingOutlined } from '@ant-design/icons';
@@ -9,6 +9,8 @@ import { SettingsContext } from '../../lib/contexts/SettingsContext';
 import { LineTypes } from '../viewer/ReplayLines';
 import SideDrawerExpandButton from '../common/SideDrawerExpandButton';
 import useWindowDimensions from '../../lib/hooks/useWindowDimensions';
+import GlobalTimeLineInfos from '../../lib/singletons/timeLineInfos';
+import Text from 'antd/lib/typography/Text';
 
 const SidebarSettings = (): JSX.Element => {
     const [visible, setVisible] = useState(false);
@@ -20,9 +22,13 @@ const SidebarSettings = (): JSX.Element => {
         showInputOverlay, setShowInputOverlay,
         replayLineOpacity, setReplayLineOpacity,
         replayCarOpacity, setReplayCarOpacity,
+        showFullTrail, setShowFullTrail,
+        showTrailToStart, setShowTrailToStart,
     } = useContext(
         SettingsContext,
     );
+
+    const timeLineGlobal = GlobalTimeLineInfos.getInstance();
 
     const onClose = () => {
         setVisible(false);
@@ -108,6 +114,56 @@ const SidebarSettings = (): JSX.Element => {
                                     value={typeof replayCarOpacity === 'number' ? replayCarOpacity : 0}
                                     step={0.1}
                                     dots
+                                />
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="flex flex-col gap-4">
+                        <div className="text-xl font-semibold">Trails</div>
+                        <div className="flex items-center">
+                            <Checkbox
+                                className="select-none"
+                                checked={showFullTrail}
+                                onChange={(e) => {
+                                    setShowFullTrail(e.target.checked);
+                                    timeLineGlobal.showFullTrail = e.target.checked;
+                                }}
+                            >
+                                Show full trail
+                            </Checkbox>
+                        </div>
+                        <div className="flex items-center">
+                            <Checkbox
+                                className="select-none"
+                                disabled={showFullTrail}
+                                checked={showTrailToStart}
+                                onChange={(e) => {
+                                    setShowTrailToStart(e.target.checked);
+                                    timeLineGlobal.showTrailToStart = e.target.checked;
+                                }}
+                            >
+                                Show trail to start
+                            </Checkbox>
+                        </div>
+                        <div className="flex items-center">
+                            <div className="flex-grow">
+                                <Text disabled={showFullTrail || showTrailToStart}>Trail length:</Text>
+                            </div>
+                            <div className="w-3/5 px-1">
+                                <InputNumber
+                                    addonAfter="ms"
+                                    className="w-full"
+                                    disabled={showFullTrail || showTrailToStart}
+                                    defaultValue={timeLineGlobal.revealTrailTime}
+                                    min={0}
+                                    step={100}
+                                    precision={0}
+                                    onChange={(e) => {
+                                        if (typeof e === 'number') {
+                                            timeLineGlobal.revealTrailTime = e;
+                                        }
+                                    }}
                                 />
                             </div>
                         </div>

--- a/app/components/viewer/ReplayLines.tsx
+++ b/app/components/viewer/ReplayLines.tsx
@@ -90,7 +90,7 @@ const ReplayLine = ({
                 // Index before minimum index, hide line: set alpha to 0
                 bufferGeom.current.attributes.color.setW(i, 0);
             } else if (i < endFadeIndexClamped) {
-                // Index after trail start, before fade start, fade alpha between 0 and 1
+                // Index after trail start, before fade end, fade alpha between 0 and 1
                 const alpha = (i - startTrailIndexClamped) / (endFadeIndexClamped - startTrailIndexClamped);
                 bufferGeom.current.attributes.color.setW(i, alpha);
             } else {

--- a/app/components/viewer/ReplayLines.tsx
+++ b/app/components/viewer/ReplayLines.tsx
@@ -55,8 +55,19 @@ const ReplayLine = ({
     useFrame(() => {
         if (!bufferGeom.current) return;
 
+        const TRAIL_TIME_MS = 1000;
+
         const sampleIndex = getSampleIndexNearTime(replay, timeLineGlobal.currentRaceTime);
-        bufferGeom.current.setDrawRange(0, sampleIndex);
+        const sampleIndexMin = Math.max(
+            0,
+            getSampleIndexNearTime(replay, timeLineGlobal.currentRaceTime - TRAIL_TIME_MS),
+        );
+
+        const diff = sampleIndex - sampleIndexMin;
+        const minIndexClamped = Math.max(0, Math.min(sampleIndex - diff, replay.samples.length));
+        const numSamplesToDraw = Math.min(Math.max(sampleIndex, sampleIndex - diff), diff);
+
+        bufferGeom.current.setDrawRange(minIndexClamped, numSamplesToDraw);
     });
 
     return (

--- a/app/components/viewer/ReplayLines.tsx
+++ b/app/components/viewer/ReplayLines.tsx
@@ -46,8 +46,13 @@ const ReplayLine = ({
     const points = useMemo(() => replay.samples.map((sample) => sample.position), [replay.samples]);
     const colorBuffer = useMemo(() => {
         const colors = lineType.colorsCallback(replay);
+
+        // Set alpha to 0 by default to avoid flickering, it will be set to the correct value in the replay trail hook
         return addAlphaChannel(colors, 0);
-    }, [replay, lineType]);
+
+        // We need the 'replay.color' variable to be in the dependency array, otherwise the colors will not update
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [replay, replay.color, lineType]);
 
     const onUpdate = useCallback(
         (self) => {

--- a/app/components/viewer/ReplayLines.tsx
+++ b/app/components/viewer/ReplayLines.tsx
@@ -9,6 +9,7 @@ import {
     rpmReplayColors,
     speedReplayColors,
     inputReplayColors,
+    addAlphaChannel,
 } from '../../lib/replays/replayLineColors';
 import GlobalTimeLineInfos from '../../lib/singletons/timeLineInfos';
 import { getSampleIndexNearTime, getSampleNearTime } from '../../lib/utils/replay';
@@ -16,6 +17,9 @@ import ReplayChartHoverLocation from './ReplayChartHoverLocation';
 import ReplayDnf from './ReplayDnf';
 import ReplayGears from './ReplayGears';
 import ReplaySectorHighlights from './ReplaySectorHighlights';
+
+// Fade the end of segment of the trail, length in terms of time of the fading part of the trail in ms
+const TRAIL_FADE_SEGMENT_TIME = 1000;
 
 export interface LineType {
     name: string;
@@ -40,7 +44,10 @@ const ReplayLine = ({
 }: ReplayLineProps) => {
     const bufferGeom = useRef<THREE.BufferGeometry>();
     const points = useMemo(() => replay.samples.map((sample) => sample.position), [replay.samples]);
-    const colorBuffer = useMemo(() => lineType.colorsCallback(replay), [replay, lineType, replay.color]);
+    const colorBuffer = useMemo(() => {
+        const colors = lineType.colorsCallback(replay);
+        return addAlphaChannel(colors);
+    }, [replay, lineType]);
 
     const timeLineGlobal = GlobalTimeLineInfos.getInstance();
 
@@ -62,19 +69,39 @@ const ReplayLine = ({
             return;
         }
 
-        const sampleIndex = getSampleIndexNearTime(replay, timeLineGlobal.currentRaceTime);
-        const sampleIndexMin = showTrailToStart
-            ? 0
-            : Math.max(
-                0,
-                getSampleIndexNearTime(replay, timeLineGlobal.currentRaceTime - revealTrailTime),
-            );
+        // Get sample and trail indices
+        const curSampleIndex = getSampleIndexNearTime(replay, timeLineGlobal.currentRaceTime);
+        const startTrailIndex = showTrailToStart ? 0 : getSampleIndexNearTime(
+            replay,
+            timeLineGlobal.currentRaceTime - revealTrailTime,
+        );
 
-        const diff = sampleIndex - sampleIndexMin;
-        const minIndexClamped = Math.max(0, Math.min(sampleIndex - diff, replay.samples.length));
-        const numSamplesToDraw = Math.min(Math.max(sampleIndex, sampleIndex - diff), diff);
+        const endFadeIndex = showTrailToStart ? 0 : getSampleIndexNearTime(
+            replay,
+            timeLineGlobal.currentRaceTime - revealTrailTime + TRAIL_FADE_SEGMENT_TIME,
+        );
 
-        bufferGeom.current.setDrawRange(minIndexClamped, numSamplesToDraw);
+        // Clamp indices
+        const startTrailIndexClamped = Math.max(0, Math.min(startTrailIndex, replay.samples.length));
+        const endFadeIndexClamped = Math.max(0, Math.min(endFadeIndex, curSampleIndex, replay.samples.length));
+
+        for (let i = 0; i < curSampleIndex; i++) {
+            if (i < startTrailIndexClamped) {
+                // Index before minimum index, hide line: set alpha to 0
+                bufferGeom.current.attributes.color.setW(i, 0);
+            } else if (i < endFadeIndexClamped) {
+                // Index after trail start, before fade start, fade alpha between 0 and 1
+                const alpha = (i - startTrailIndexClamped) / (endFadeIndexClamped - startTrailIndexClamped);
+                bufferGeom.current.attributes.color.setW(i, alpha);
+            } else {
+                // Index after fade end, show line: set alpha to 1
+                bufferGeom.current.attributes.color.setW(i, 1);
+            }
+        }
+        bufferGeom.current.attributes.color.needsUpdate = true;
+
+        const samplesToDraw = curSampleIndex - startTrailIndexClamped;
+        bufferGeom.current.setDrawRange(startTrailIndexClamped, samplesToDraw);
     });
 
     return (

--- a/app/components/viewer/ReplayLines.tsx
+++ b/app/components/viewer/ReplayLines.tsx
@@ -34,11 +34,9 @@ interface ReplayLineProps {
     replay: ReplayData;
     lineType: LineType;
     replayLineOpacity: number;
-    revealTrail?: boolean;
-    revealTrailTime?: number;
 }
 const ReplayLine = ({
-    replay, lineType, replayLineOpacity, revealTrail, revealTrailTime,
+    replay, lineType, replayLineOpacity,
 }: ReplayLineProps) => {
     const bufferGeom = useRef<THREE.BufferGeometry>();
     const points = useMemo(() => replay.samples.map((sample) => sample.position), [replay.samples]);
@@ -57,18 +55,20 @@ const ReplayLine = ({
     useFrame(() => {
         if (!bufferGeom.current) return;
 
-        if (!revealTrail) {
+        const { showFullTrail, showTrailToStart, revealTrailTime } = timeLineGlobal;
+
+        if (showFullTrail) {
             bufferGeom.current.setDrawRange(0, points.length);
             return;
         }
 
         const sampleIndex = getSampleIndexNearTime(replay, timeLineGlobal.currentRaceTime);
-        const sampleIndexMin = (revealTrailTime !== undefined)
-            ? Math.max(
+        const sampleIndexMin = showTrailToStart
+            ? 0
+            : Math.max(
                 0,
                 getSampleIndexNearTime(replay, timeLineGlobal.currentRaceTime - revealTrailTime),
-            )
-            : 0;
+            );
 
         const diff = sampleIndex - sampleIndexMin;
         const minIndexClamped = Math.max(0, Math.min(sampleIndex - diff, replay.samples.length));
@@ -112,7 +112,6 @@ export const ReplayLines = ({
                     replay={replay}
                     lineType={lineType}
                     replayLineOpacity={replayLineOpacity}
-                    revealTrail
                 />
                 <ReplayChartHoverLocation
                     key={`replay-${replay._id}-chart-hover`}

--- a/app/lib/contexts/SettingsContext.tsx
+++ b/app/lib/contexts/SettingsContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useState } from 'react';
 import { LineType, LineTypes } from '../../components/viewer/ReplayLines';
+import GlobalTimeLineInfos from '../singletons/timeLineInfos';
 
 // eslint false positive https://stackoverflow.com/questions/63961803/
 // eslint-disable-next-line no-shadow
@@ -7,6 +8,9 @@ export enum CameraMode {
     Target,
     Follow,
 }
+
+// Timeline singleton used to intialize settings context values to the same values
+const timeLineInfos = GlobalTimeLineInfos.getInstance();
 
 export interface SettingsContextProps {
     lineType: LineType;
@@ -23,6 +27,10 @@ export interface SettingsContextProps {
     setReplayCarOpacity: (setReplayCarOpacity: number) => void;
     numColorChange: number;
     setNumColorChange: (numColorChange: number) => void;
+    showFullTrail: boolean;
+    setShowFullTrail: (showFullTrail: boolean) => void;
+    showTrailToStart: boolean;
+    setShowTrailToStart: (showFullTrail: boolean) => void;
 }
 
 export const SettingsContext = createContext<SettingsContextProps>({
@@ -40,6 +48,10 @@ export const SettingsContext = createContext<SettingsContextProps>({
     setReplayCarOpacity: () => { },
     numColorChange: 0,
     setNumColorChange: () => { },
+    showFullTrail: timeLineInfos.showFullTrail,
+    setShowFullTrail: () => { },
+    showTrailToStart: timeLineInfos.showTrailToStart,
+    setShowTrailToStart: () => { },
 });
 
 export const SettingsProvider = ({ children }: any): JSX.Element => {
@@ -50,6 +62,8 @@ export const SettingsProvider = ({ children }: any): JSX.Element => {
     const [replayLineOpacity, setReplayLineOpacity] = useState(0.5);
     const [replayCarOpacity, setReplayCarOpacity] = useState(0.5);
     const [numColorChange, setNumColorChange] = useState(0);
+    const [showFullTrail, setShowFullTrail] = useState(timeLineInfos.showFullTrail);
+    const [showTrailToStart, setShowTrailToStart] = useState(timeLineInfos.showTrailToStart);
 
     const changeLineType = (type: LineType) => {
         setLineType(type);
@@ -72,6 +86,10 @@ export const SettingsProvider = ({ children }: any): JSX.Element => {
                 setReplayCarOpacity,
                 numColorChange,
                 setNumColorChange,
+                showFullTrail,
+                setShowFullTrail,
+                showTrailToStart,
+                setShowTrailToStart,
             }}
         >
             {children}

--- a/app/lib/hooks/viewer/replayLines/useUpdateReplayLineTrail.ts
+++ b/app/lib/hooks/viewer/replayLines/useUpdateReplayLineTrail.ts
@@ -1,0 +1,116 @@
+import { useFrame } from '@react-three/fiber';
+import React, { useRef } from 'react';
+import * as THREE from 'three';
+import { ReplayData } from '../../../api/apiRequests';
+import GlobalTimeLineInfos from '../../../singletons/timeLineInfos';
+import { getSampleIndexNearTime } from '../../../utils/replay';
+
+interface LineUpdateIndices {
+    startIndex: number;
+    endIndex: number;
+    segmentUpdate: boolean;
+}
+
+const useUpdateReplayLineTrail = (
+    bufferRef: React.MutableRefObject<THREE.BufferGeometry | undefined>,
+    replay: ReplayData,
+    trailFadeTime: number,
+) => {
+    const timeLineGlobal = GlobalTimeLineInfos.getInstance();
+
+    const previousLineUpdate = useRef<LineUpdateIndices>();
+
+    const updateLineTrail = () => {
+        if (!bufferRef.current) return;
+
+        const {
+            showFullTrail, showTrailToStart, revealTrailTime, currentRaceTime,
+        } = timeLineGlobal;
+
+        const curSampleIndex = getSampleIndexNearTime(replay, timeLineGlobal.currentRaceTime);
+
+        if (showFullTrail || showTrailToStart) {
+            if (!previousLineUpdate.current || previousLineUpdate.current.segmentUpdate) {
+                // Reset alpha of full line if it's the first update or if the previous update was a segment update
+                for (let i = 0; i < replay.samples.length; i++) {
+                    bufferRef.current.attributes.color.setW(i, 1);
+                }
+                bufferRef.current.attributes.color.needsUpdate = true;
+            }
+
+            if (showFullTrail) {
+                bufferRef.current.setDrawRange(0, replay.samples.length);
+            } else {
+                bufferRef.current.setDrawRange(0, curSampleIndex);
+            }
+
+            previousLineUpdate.current = {
+                startIndex: 0,
+                endIndex: replay.samples.length,
+                segmentUpdate: false,
+            };
+        } else {
+            // Get trail indices
+            const startTrailIndex = getSampleIndexNearTime(
+                replay,
+                currentRaceTime - revealTrailTime,
+            );
+            const endFadeIndex = getSampleIndexNearTime(
+                replay,
+                currentRaceTime - revealTrailTime + trailFadeTime,
+            );
+
+            // Clamp trail indices
+            const startTrailIndexClamped = Math.max(0, Math.min(startTrailIndex, replay.samples.length));
+            const endFadeIndexClamped = Math.max(0, Math.min(endFadeIndex, curSampleIndex, replay.samples.length));
+
+            const prev = previousLineUpdate.current;
+            // Update starts at trail index or previous start index (or 0 if no previous update has occured)
+            const updateStart = Math.min(startTrailIndexClamped, prev?.startIndex || 0);
+            // Update starts at sample index or previous end index (or end of line if no previous update has occured)
+            const updateEnd = Math.max(curSampleIndex, prev?.endIndex || replay.samples.length);
+
+            // Update line alpha if needed (previous was not a segment update or update range changed)
+            if (!prev?.segmentUpdate || updateStart !== prev?.startIndex || updateEnd !== prev?.endIndex) {
+                for (let i = updateStart; i < updateEnd; i++) {
+                    if (i < startTrailIndexClamped) {
+                        // Index before minimum index, hide line: set alpha to 0
+                        bufferRef.current.attributes.color.setW(i, 0);
+                    } else if (i < endFadeIndexClamped) {
+                        // Index after trail start, before fade end, fade alpha between 0 and 1
+                        const alpha = (i - startTrailIndexClamped) / (endFadeIndexClamped - startTrailIndexClamped);
+                        bufferRef.current.attributes.color.setW(i, alpha);
+                    } else {
+                        // Index after fade end, show line: set alpha to 1
+                        bufferRef.current.attributes.color.setW(i, 1);
+                    }
+                }
+                bufferRef.current.attributes.color.needsUpdate = true;
+            }
+
+            // Set line draw range
+            const samplesToDraw = curSampleIndex - startTrailIndexClamped;
+            bufferRef.current.setDrawRange(startTrailIndexClamped, samplesToDraw);
+
+            // Set start and end to trail start and end
+            previousLineUpdate.current = {
+                startIndex: startTrailIndexClamped,
+                endIndex: curSampleIndex,
+                segmentUpdate: true,
+            };
+        }
+    };
+
+    useFrame(() => {
+        updateLineTrail();
+    });
+
+    const manualLineTrailUpdate = () => {
+        previousLineUpdate.current = undefined;
+        updateLineTrail();
+    };
+
+    return { manualLineTrailUpdate };
+};
+
+export default useUpdateReplayLineTrail;

--- a/app/lib/replays/replayLineColors.ts
+++ b/app/lib/replays/replayLineColors.ts
@@ -137,3 +137,12 @@ export const inputReplayColors = (replay: ReplayData): THREE.Float32BufferAttrib
     }
     return new THREE.Float32BufferAttribute(colorBuffer, 3);
 };
+
+export const addAlphaChannel = (rgbBuffer: THREE.Float32BufferAttribute) => {
+    const alphaList = [];
+    for (let i = 0; i < rgbBuffer.count; i++) {
+        alphaList.push(rgbBuffer.getX(i), rgbBuffer.getY(i), rgbBuffer.getZ(i), 1);
+    }
+    const alphaBuffer = new THREE.Float32BufferAttribute(alphaList, 4);
+    return alphaBuffer;
+};

--- a/app/lib/replays/replayLineColors.ts
+++ b/app/lib/replays/replayLineColors.ts
@@ -138,10 +138,10 @@ export const inputReplayColors = (replay: ReplayData): THREE.Float32BufferAttrib
     return new THREE.Float32BufferAttribute(colorBuffer, 3);
 };
 
-export const addAlphaChannel = (rgbBuffer: THREE.Float32BufferAttribute) => {
+export const addAlphaChannel = (rgbBuffer: THREE.Float32BufferAttribute, alpha: number = 1) => {
     const alphaList = [];
     for (let i = 0; i < rgbBuffer.count; i++) {
-        alphaList.push(rgbBuffer.getX(i), rgbBuffer.getY(i), rgbBuffer.getZ(i), 1);
+        alphaList.push(rgbBuffer.getX(i), rgbBuffer.getY(i), rgbBuffer.getZ(i), alpha);
     }
     const alphaBuffer = new THREE.Float32BufferAttribute(alphaList, 4);
     return alphaBuffer;

--- a/app/lib/singletons/timeLineInfos.ts
+++ b/app/lib/singletons/timeLineInfos.ts
@@ -10,12 +10,19 @@ class TimeLineInfos {
     hoveredReplay: ReplayData | undefined;
     isPlaying: boolean;
     cameraMode: CameraMode;
+    showFullTrail: boolean;
+    showTrailToStart: boolean;
+    revealTrailTime: number;
+
     constructor() {
         this.tickTime = 1000 / 60;
         this.currentRaceTime = 0;
         this.maxRaceTime = 0;
         this.isPlaying = false;
         this.cameraMode = CameraMode.Follow;
+        this.showFullTrail = true;
+        this.showTrailToStart = false;
+        this.revealTrailTime = 1000;
     }
 }
 

--- a/app/lib/singletons/timeLineInfos.ts
+++ b/app/lib/singletons/timeLineInfos.ts
@@ -21,7 +21,7 @@ class TimeLineInfos {
         this.isPlaying = false;
         this.cameraMode = CameraMode.Follow;
         this.showFullTrail = true;
-        this.showTrailToStart = false;
+        this.showTrailToStart = true;
         this.revealTrailTime = 1000;
     }
 }

--- a/app/lib/utils/replay.ts
+++ b/app/lib/utils/replay.ts
@@ -24,7 +24,7 @@ export const interpolateSamples = (
     smooth.speed = interpolateFloat(prev.speed, current.speed, factor);
 };
 
-export const getSampleNearTime = (replay: ReplayData, raceTime: number): ReplayDataPoint => {
+export const getSampleIndexNearTime = (replay: ReplayData, raceTime: number): number => {
     // First sample index guess based on median data point interval
     let sampleIndex = Math.round(raceTime / replay.intervalMedian);
     sampleIndex = Math.min(Math.max(0, sampleIndex), replay.samples.length - 1);
@@ -40,5 +40,10 @@ export const getSampleNearTime = (replay: ReplayData, raceTime: number): ReplayD
         sampleIndex++;
     }
 
+    return sampleIndex;
+};
+
+export const getSampleNearTime = (replay: ReplayData, raceTime: number): ReplayDataPoint => {
+    const sampleIndex = getSampleIndexNearTime(replay, raceTime);
     return replay.samples[sampleIndex];
 };


### PR DESCRIPTION
Still to add/fix:
- [x] Fading opacity of lines when past X seconds are drawn
- [x] When loading a replay, the complete line is rendered for a split second, regardless of the trail settings
- [x] Reset alpha to 1 for the whole line when changing setting to render the complete line
- [x] Optimize setting alpha values, they are currently being update for every single entry, instead of just the parts that require updates

---

Adds settings to customize replay line trails:
1. Regular line rendering, render complete line
2. Only render replay line from car to the start: reveals line during play
3. Only render a replay line segment of X seconds behind the car: reveals the part directly behind the car while playing, line disappears further than X seconds behind the car

Best demo is checking it out in the preview, loading some replays and adjust the settings in the settings sidebar. Link: https://tm-dojo-git-revealing-replay-line-while-playing-bux42.vercel.app/