### PR TITLE
Hotfix target origin in auth redirect page for prod domain

### DIFF
--- a/app/pages/auth_redirect/index.tsx
+++ b/app/pages/auth_redirect/index.tsx
@@ -12,6 +12,7 @@ const AuthRedirect = (): JSX.Element => {
 
     const isAllowedTargetOrigin = (targetOrigin: string): boolean => (
         targetOrigin === 'https://www.tmdojo.com'
+        || targetOrigin === 'https://tmdojo.com'
         || targetOrigin === 'http://localhost:4200'
         || (targetOrigin.startsWith('https://tm-dojo-git-') && targetOrigin.endsWith('.vercel.app'))
     );


### PR DESCRIPTION
Add `https://tmdojo.com` to allowed target origins of auth redirect page