### PR TITLE
Add server compression

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,6 +11,7 @@
 				"@aws-sdk/client-s3": "^3.24.0",
 				"axios": "^0.21.1",
 				"body-parser": "^1.19.0",
+				"compression": "^1.7.4",
 				"cookie-parser": "^1.4.5",
 				"cors": "^2.8.5",
 				"dayjs": "^1.10.6",
@@ -25,6 +26,7 @@
 			"devDependencies": {
 				"@aws-sdk/types": "^3.22.0",
 				"@types/axios": "^0.14.0",
+				"@types/compression": "^1.7.2",
 				"@types/cookie-parser": "^1.4.2",
 				"@types/cors": "^2.8.10",
 				"@types/express": "^4.17.13",
@@ -1335,6 +1337,15 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/compression": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/@types/compression/-/compression-1.7.2.tgz",
+			"integrity": "sha512-lwEL4M/uAGWngWFLSG87ZDr2kLrbuR8p7X+QZB1OQlT+qkHsCPDVFnHPyXf4Vyl4yDDorNY+mAhosxkCvppatg==",
+			"dev": true,
+			"dependencies": {
+				"@types/express": "*"
+			}
+		},
 		"node_modules/@types/connect": {
 			"version": "3.4.35",
 			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -1578,80 +1589,6 @@
 				"typescript": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-			"version": "4.29.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.0.tgz",
-			"integrity": "sha512-HPq7XAaDMM3DpmuijxLV9Io8/6pQnliiXMQUcAdjpJJSR+fdmbD/zHCd7hMkjJn04UQtCQBtshgxClzg6NIS2w==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/types": "4.29.0",
-				"@typescript-eslint/visitor-keys": "4.29.0"
-			},
-			"engines": {
-				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-			"version": "4.29.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.0.tgz",
-			"integrity": "sha512-2YJM6XfWfi8pgU2HRhTp7WgRw78TCRO3dOmSpAvIQ8MOv4B46JD2chnhpNT7Jq8j0APlIbzO1Bach734xxUl4A==",
-			"dev": true,
-			"engines": {
-				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "4.29.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.0.tgz",
-			"integrity": "sha512-8ZpNHDIOyqzzgZrQW9+xQ4k5hM62Xy2R4RPO3DQxMc5Rq5QkCdSpk/drka+DL9w6sXNzV5nrdlBmf8+x495QXQ==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/types": "4.29.0",
-				"@typescript-eslint/visitor-keys": "4.29.0",
-				"debug": "^4.3.1",
-				"globby": "^11.0.3",
-				"is-glob": "^4.0.1",
-				"semver": "^7.3.5",
-				"tsutils": "^3.21.0"
-			},
-			"engines": {
-				"node": "^10.12.0 || >=12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "4.29.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.0.tgz",
-			"integrity": "sha512-LoaofO1C/jAJYs0uEpYMXfHboGXzOJeV118X4OsZu9f7rG7Pr9B3+4HTU8+err81rADa4xfQmAxnRnPAI2jp+Q==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/types": "4.29.0",
-				"eslint-visitor-keys": "^2.0.0"
-			},
-			"engines": {
-				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
 		"node_modules/@typescript-eslint/parser/node_modules/debug": {
@@ -2400,6 +2337,42 @@
 			"dependencies": {
 				"color": "^3.1.3",
 				"text-hex": "1.0.x"
+			}
+		},
+		"node_modules/compressible": {
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+			"integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+			"dependencies": {
+				"mime-db": ">= 1.43.0 < 2"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/compression": {
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+			"integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+			"dependencies": {
+				"accepts": "~1.3.5",
+				"bytes": "3.0.0",
+				"compressible": "~2.0.16",
+				"debug": "2.6.9",
+				"on-headers": "~1.0.2",
+				"safe-buffer": "5.1.2",
+				"vary": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/compression/node_modules/bytes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+			"integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/concat-map": {
@@ -4543,6 +4516,14 @@
 			"dependencies": {
 				"ee-first": "1.1.1"
 			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/on-headers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+			"integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -7087,6 +7068,15 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/compression": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/@types/compression/-/compression-1.7.2.tgz",
+			"integrity": "sha512-lwEL4M/uAGWngWFLSG87ZDr2kLrbuR8p7X+QZB1OQlT+qkHsCPDVFnHPyXf4Vyl4yDDorNY+mAhosxkCvppatg==",
+			"dev": true,
+			"requires": {
+				"@types/express": "*"
+			}
+		},
 		"@types/connect": {
 			"version": "3.4.35",
 			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -7278,47 +7268,6 @@
 				"debug": "^4.3.1"
 			},
 			"dependencies": {
-				"@typescript-eslint/scope-manager": {
-					"version": "4.29.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.0.tgz",
-					"integrity": "sha512-HPq7XAaDMM3DpmuijxLV9Io8/6pQnliiXMQUcAdjpJJSR+fdmbD/zHCd7hMkjJn04UQtCQBtshgxClzg6NIS2w==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "4.29.0",
-						"@typescript-eslint/visitor-keys": "4.29.0"
-					}
-				},
-				"@typescript-eslint/types": {
-					"version": "4.29.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.0.tgz",
-					"integrity": "sha512-2YJM6XfWfi8pgU2HRhTp7WgRw78TCRO3dOmSpAvIQ8MOv4B46JD2chnhpNT7Jq8j0APlIbzO1Bach734xxUl4A==",
-					"dev": true
-				},
-				"@typescript-eslint/typescript-estree": {
-					"version": "4.29.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.0.tgz",
-					"integrity": "sha512-8ZpNHDIOyqzzgZrQW9+xQ4k5hM62Xy2R4RPO3DQxMc5Rq5QkCdSpk/drka+DL9w6sXNzV5nrdlBmf8+x495QXQ==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "4.29.0",
-						"@typescript-eslint/visitor-keys": "4.29.0",
-						"debug": "^4.3.1",
-						"globby": "^11.0.3",
-						"is-glob": "^4.0.1",
-						"semver": "^7.3.5",
-						"tsutils": "^3.21.0"
-					}
-				},
-				"@typescript-eslint/visitor-keys": {
-					"version": "4.29.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.0.tgz",
-					"integrity": "sha512-LoaofO1C/jAJYs0uEpYMXfHboGXzOJeV118X4OsZu9f7rG7Pr9B3+4HTU8+err81rADa4xfQmAxnRnPAI2jp+Q==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "4.29.0",
-						"eslint-visitor-keys": "^2.0.0"
-					}
-				},
 				"debug": {
 					"version": "4.3.2",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -7866,6 +7815,35 @@
 			"requires": {
 				"color": "^3.1.3",
 				"text-hex": "1.0.x"
+			}
+		},
+		"compressible": {
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+			"integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+			"requires": {
+				"mime-db": ">= 1.43.0 < 2"
+			}
+		},
+		"compression": {
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+			"integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+			"requires": {
+				"accepts": "~1.3.5",
+				"bytes": "3.0.0",
+				"compressible": "~2.0.16",
+				"debug": "2.6.9",
+				"on-headers": "~1.0.2",
+				"safe-buffer": "5.1.2",
+				"vary": "~1.1.2"
+			},
+			"dependencies": {
+				"bytes": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+					"integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw=="
+				}
 			}
 		},
 		"concat-map": {
@@ -9487,6 +9465,11 @@
 			"requires": {
 				"ee-first": "1.1.1"
 			}
+		},
+		"on-headers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+			"integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
 		},
 		"once": {
 			"version": "1.4.0",

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
 		"@aws-sdk/client-s3": "^3.24.0",
 		"axios": "^0.21.1",
 		"body-parser": "^1.19.0",
+		"compression": "^1.7.4",
 		"cookie-parser": "^1.4.5",
 		"cors": "^2.8.5",
 		"dayjs": "^1.10.6",
@@ -26,6 +27,7 @@
 	"devDependencies": {
 		"@aws-sdk/types": "^3.22.0",
 		"@types/axios": "^0.14.0",
+		"@types/compression": "^1.7.2",
 		"@types/cookie-parser": "^1.4.2",
 		"@types/cors": "^2.8.10",
 		"@types/express": "^4.17.13",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs';
 import * as cors from 'cors';
 import * as bodyParser from 'body-parser';
 import * as cookieParser from 'cookie-parser';
+import * as compression from 'compression';
 
 import * as db from './lib/db';
 import { logError, logInfo, initLogger } from './lib/logger';
@@ -62,6 +63,9 @@ app.use(bodyParser.json());
 
 // Cookie Parser middleware
 app.use(cookieParser());
+
+// Response compression (using fastest compression preset)
+app.use(compression({ level: 1 }));
 
 app.listen(defaultPort, () => {
     logInfo(`App listening on port ${defaultPort}`);


### PR DESCRIPTION
Use `compression` npm package for response compression. Using the default compression level (6) slowed the request down a bit, so I chose the fastest level (1) as the compression level.

Trying the `/maps` endpoint locally
No compression: 2.2 MB in ~180-190ms
Default compression (level 6): 908 kB in ~220-240ms
Fastest compression (level 1): 956 Kb in ~190-200ms