### PR TITLE
Use query mapUId for navigation between viewer and stats page

### DIFF
--- a/app/pages/maps/[mapUId]/index.tsx
+++ b/app/pages/maps/[mapUId]/index.tsx
@@ -153,9 +153,9 @@ const Home = (): JSX.Element => {
             <Layout>
                 <MapHeader mapInfo={mapInfo} title="Replay viewer" backUrl="/">
                     <CleanButton
-                        url={`/maps/${mapInfo?.mapUid}/stats`}
+                        url={`/maps/${mapUId}/stats`}
                         backColor="hsl(0, 0%, 15%)"
-                        disabled={mapInfo === undefined}
+                        disabled={mapUId === undefined}
                     >
                         <div className="flex gap-2 items-center">
                             <PieChartOutlined />

--- a/app/pages/maps/[mapUId]/stats.tsx
+++ b/app/pages/maps/[mapUId]/stats.tsx
@@ -28,21 +28,20 @@ const MapStats = () => {
     const [mapStatsType, setMapStatsType] = useState(MapStatsType.GLOBAL);
 
     const router = useRouter();
-    const { mapUId } = router.query;
+    const { mapUId: rawMapUId } = router.query;
+    const mapUId = useMemo(() => (typeof rawMapUId === 'string' ? rawMapUId : undefined), [rawMapUId]);
 
     const {
         data: mapReplayData,
         isLoading: isLoadingReplays,
-    } = useMapReplays(typeof mapUId === 'string' ? mapUId : undefined);
+    } = useMapReplays(mapUId);
 
     const replays = useMemo(
         () => mapReplayData?.replays || [],
         [mapReplayData?.replays],
     );
 
-    const {
-        data: mapInfo,
-    } = useMapInfo(typeof mapUId === 'string' ? mapUId : undefined);
+    const { data: mapInfo } = useMapInfo(mapUId);
 
     // If user object changes, set the according map stats type
     useEffect(() => {
@@ -111,9 +110,9 @@ const MapStats = () => {
                 backUrl="/"
             >
                 <CleanButton
-                    url={`/maps/${mapInfo?.mapUid}`}
+                    url={`/maps/${mapUId}`}
                     backColor="hsl(0, 0%, 15%)"
-                    disabled={mapInfo === undefined}
+                    disabled={mapUId === undefined}
                 >
                     <div className="flex gap-2 items-center">
                         <PlaySquareOutlined />


### PR DESCRIPTION
Fix issue for non-uploaded maps where the fetched mapUId was `undefined` and did now work well with navigation between those 2 pages. This PR uses the query mapUId for navigation.