### PR TITLE
Adjust speed color map (adjusted colors + larger range)

### DIFF
--- a/app/lib/replays/replayLineColors.ts
+++ b/app/lib/replays/replayLineColors.ts
@@ -5,8 +5,9 @@ import { ColorMap, getColorFromMap } from '../utils/colormaps';
 import { ReplayDataPoint } from './replayData';
 
 const COLOR_MAP_SPEED: ColorMap = [
-    { value: 0, color: { r: 0xff, g: 0x00, b: 0 } },
-    { value: 200, color: { r: 0x00, g: 0xff, b: 0 } },
+    { value: 0, color: { r: 0, g: 0, b: 0.8 * 255 } },
+    { value: 300, color: { r: 0, g: 0.8 * 255, b: 0 } },
+    { value: 600, color: { r: 0.8 * 255, g: 0, b: 0 } },
 ];
 
 const COLOR_MAP_ACCELERATION: ColorMap = [


### PR DESCRIPTION
Change speed color map, to show colors for a larger range.

## After
- `0`: Blue
- `300`: Green
- `600`: Red
<img src="https://github.com/Bux42/TMDojo/assets/22432233/ceac3889-0d65-4b23-8c2a-680147cc5115" width=700/>

## Before
- `0`: Red
- `200`: Green
<img src="https://github.com/Bux42/TMDojo/assets/22432233/0dce86e0-c636-4ac9-a860-5adb4a1d8bfe" width=700/>
