### PR TITLE
Add missing sort arguments get maps request

### DIFF
--- a/app/components/landing/MapReplayTableWithSearchbar.tsx
+++ b/app/components/landing/MapReplayTableWithSearchbar.tsx
@@ -12,7 +12,11 @@ import {
     useMapCount,
     useReplayCount,
 } from '../../lib/api/reactQuery/hooks/query/maps';
-import { MapWithStats } from '../../lib/api/requests/maps';
+import {
+    MapSortBy,
+    MapSortOrder,
+    MapWithStats,
+} from '../../lib/api/requests/maps';
 import QUERY_KEYS from '../../lib/api/reactQuery/queryKeys';
 
 interface ExtendedAvailableMap extends MapWithStats {
@@ -26,6 +30,8 @@ const MapReplayTableWithSearchbar = () => {
 
     const [searchString, setSearchString] = useState<string>('');
     const [page, setPage] = useState<number>(1);
+    const [sortBy, setSortBy] = useState<MapSortBy>('last_updated');
+    const [sortOrder, setSortOrder] = useState<MapSortOrder>('desc');
 
     const offset = (page - 1) * PAGE_SIZE;
 
@@ -33,16 +39,12 @@ const MapReplayTableWithSearchbar = () => {
         data: maps,
         isLoading,
         isFetching,
-    } = useAllMaps(searchString, offset, PAGE_SIZE);
+    } = useAllMaps(searchString, offset, PAGE_SIZE, sortBy, sortOrder);
+    const isMapsQueryPending = isLoading || isFetching;
     const { data: totalMaps, isLoading: isLoadingMapCount } =
         useMapCount(searchString);
     const { data: totalReplays, isLoading: isLoadingReplayCount } =
         useReplayCount();
-
-    const totalReplaysFromMaps = useMemo(() => {
-        if (!maps) return 0;
-        return maps.reduce((acc, map) => acc + map.count, 0);
-    }, [maps]);
 
     const tableData: ExtendedAvailableMap[] | undefined = useMemo(
         () =>
@@ -53,11 +55,16 @@ const MapReplayTableWithSearchbar = () => {
         [maps],
     );
 
+    const currentAntSortOrder: 'ascend' | 'descend' =
+        sortOrder === 'asc' ? 'ascend' : 'descend';
+
     const columns: ColumnsType<ExtendedAvailableMap> = [
         {
             title: 'Map name',
+            key: 'map_name',
             dataIndex: 'mapName',
-            sorter: (a, b) => a.mapName.localeCompare(b.mapName),
+            sorter: true,
+            sortOrder: sortBy === 'map_name' ? currentAntSortOrder : null,
             width: '60%',
             onCell: () => ({
                 style: {
@@ -71,7 +78,11 @@ const MapReplayTableWithSearchbar = () => {
                         <Link href={mapRef}>
                             <a
                                 href={mapRef}
-                                className="block p-2 w-full"
+                                className={`block p-2 w-full ${
+                                    isMapsQueryPending
+                                        ? 'pointer-events-none opacity-70'
+                                        : ''
+                                }`}
                             >
                                 {map.mapName}
                             </a>
@@ -90,6 +101,7 @@ const MapReplayTableWithSearchbar = () => {
                             size="small"
                             url={statsRef}
                             backColor="hsl(0, 0%, 9%)"
+                            disabled={isMapsQueryPending}
                         >
                             <div className="flex gap-2 items-center">
                                 <PieChartOutlined />
@@ -103,6 +115,7 @@ const MapReplayTableWithSearchbar = () => {
         },
         {
             title: 'Last updated',
+            key: 'last_updated',
             dataIndex: 'lastUpdate',
             render: (timestamp) => {
                 const today = new Date().getTime();
@@ -112,15 +125,17 @@ const MapReplayTableWithSearchbar = () => {
                     </span>
                 );
             },
-            sorter: (a, b) => a.lastUpdate - b.lastUpdate,
-            defaultSortOrder: 'descend',
+            sorter: true,
+            sortOrder: sortBy === 'last_updated' ? currentAntSortOrder : null,
             width: '15%',
         },
         {
             title: 'Replays',
+            key: 'replay_count',
             dataIndex: 'count',
             render: (count) => count.toLocaleString(),
-            sorter: (a, b) => a.count - b.count,
+            sorter: true,
+            sortOrder: sortBy === 'replay_count' ? currentAntSortOrder : null,
             width: '15%',
         },
     ];
@@ -133,12 +148,19 @@ const MapReplayTableWithSearchbar = () => {
                     placeholder="Map name"
                     size="large"
                     allowClear
-                    loading={isFetching}
+                    loading={isMapsQueryPending}
+                    disabled={isMapsQueryPending}
                     onSearch={(value) => {
                         setSearchString(value);
                         setPage(1);
                         queryClient.invalidateQueries(
-                            QUERY_KEYS.allMaps(value),
+                            QUERY_KEYS.allMaps(
+                                value,
+                                0,
+                                PAGE_SIZE,
+                                sortBy,
+                                sortOrder,
+                            ),
                         );
                         queryClient.invalidateQueries(
                             QUERY_KEYS.mapCount(value),
@@ -165,10 +187,10 @@ const MapReplayTableWithSearchbar = () => {
             </div>
 
             <Table
-                className="overflow-x-auto select-none"
+                className={`overflow-x-auto select-none ${isMapsQueryPending ? 'pointer-events-none' : ''}`}
                 columns={columns}
                 dataSource={tableData}
-                loading={isLoading}
+                loading={isMapsQueryPending}
                 onHeaderRow={() => ({
                     style: {
                         backgroundColor: '#1F1F1F',
@@ -180,12 +202,45 @@ const MapReplayTableWithSearchbar = () => {
                         backgroundColor: '#1F1F1F',
                     },
                 })}
+                onChange={(pagination, _, sorter) => {
+                    const currentSorter = Array.isArray(sorter)
+                        ? sorter[0]
+                        : sorter;
+
+                    const columnSortBy = currentSorter?.columnKey as
+                        | MapSortBy
+                        | undefined;
+                    const columnSortOrder = currentSorter?.order as
+                        | 'ascend'
+                        | 'descend'
+                        | undefined;
+
+                    if (!columnSortBy || !columnSortOrder) {
+                        setSortBy('last_updated');
+                        setSortOrder('desc');
+                    } else {
+                        const newSortBy = columnSortBy;
+                        const newSortOrder =
+                            columnSortOrder === 'ascend'
+                                ? ('asc' as MapSortOrder)
+                                : ('desc' as MapSortOrder);
+                        const sortChanged =
+                            newSortBy !== sortBy || newSortOrder !== sortOrder;
+                        setSortBy(newSortBy);
+                        setSortOrder(newSortOrder);
+                        if (sortChanged) {
+                            setPage(1);
+                            return;
+                        }
+                    }
+
+                    setPage(pagination.current ?? 1);
+                }}
                 size="small"
                 pagination={{
                     current: page,
                     pageSize: PAGE_SIZE,
                     total: totalMaps ?? 0,
-                    onChange: (newPage) => setPage(newPage),
                     position: ['bottomCenter'],
                     showSizeChanger: false,
                     size: 'small',

--- a/app/lib/api/reactQuery/hooks/query/maps.ts
+++ b/app/lib/api/reactQuery/hooks/query/maps.ts
@@ -2,12 +2,19 @@ import { useQuery } from '@tanstack/react-query';
 import queryClient from '../../queryClient';
 import QUERY_KEYS from '../../queryKeys';
 import API from '../../../apiWrapper';
+import { MapSortBy, MapSortOrder } from '../../../requests/maps';
 import { TIME_IN_MS } from '../../../../utils/time';
 
-export const useAllMaps = (searchString: string = '', offset: number = 0, limit: number = 50) =>
+export const useAllMaps = (
+    searchString: string = '',
+    offset: number = 0,
+    limit: number = 50,
+    sortBy: MapSortBy = 'last_updated',
+    sortOrder: MapSortOrder = 'desc',
+) =>
     useQuery(
-        QUERY_KEYS.allMaps(searchString, offset, limit),
-        () => API.maps.getAllMaps(searchString, offset, limit),
+        QUERY_KEYS.allMaps(searchString, offset, limit, sortBy, sortOrder),
+        () => API.maps.getAllMaps(searchString, offset, limit, sortBy, sortOrder),
     );
 
 export const useMapCount = (searchString: string = '') =>

--- a/app/lib/api/reactQuery/queryKeys.ts
+++ b/app/lib/api/reactQuery/queryKeys.ts
@@ -1,6 +1,12 @@
 const QUERY_KEYS = {
-    allMaps: (searchString: string = '', offset: number = 0, limit: number = 50) =>
-        ['allMaps', searchString, offset, limit] as const,
+    allMaps: (
+        searchString: string = '',
+        offset: number = 0,
+        limit: number = 50,
+        sortBy: 'map_name' | 'last_updated' | 'replay_count' = 'last_updated',
+        sortOrder: 'desc' | 'asc' = 'desc',
+    ) =>
+        ['allMaps', searchString, offset, limit, sortBy, sortOrder] as const,
     mapCount: (searchString: string = '') =>
         ['mapCount', searchString] as const,
     replayCount: () =>

--- a/app/lib/api/requests/maps.ts
+++ b/app/lib/api/requests/maps.ts
@@ -22,16 +22,23 @@ export type MapWithStats = {
     lastUpdate: number;
 };
 
+export type MapSortBy = 'map_name' | 'last_updated' | 'replay_count';
+export type MapSortOrder = 'desc' | 'asc';
+
 export const getAllMaps = async (
     searchString: string,
     offset: number = 0,
     limit: number = 50,
+    sortBy: MapSortBy = 'last_updated',
+    sortOrder: MapSortOrder = 'desc',
 ): Promise<MapWithStats[]> => {
     const { data } = await apiInstance.get('/maps', {
         params: {
             mapName: searchString || undefined,
             offset,
             limit,
+            sortBy,
+            sortOrder,
         },
     });
     return data.maps;

--- a/server/src/lib/db.ts
+++ b/server/src/lib/db.ts
@@ -14,6 +14,9 @@ let db: Db = null;
 
 export type Rejector = (_1: Error) => void;
 
+export type MapSortBy = 'map_name' | 'last_updated' | 'replay_count';
+export type SortOrder = 'desc' | 'asc';
+
 export const initDB = () => {
     const mongoClient = new MongoClient(process.env.MONGO_URL, {
         useUnifiedTopology: true,
@@ -133,9 +136,12 @@ export const getPaginatedMaps = async (
     mapName?: string,
     offset: number = 0,
     limit: number = 50,
+    sortBy: MapSortBy = 'last_updated',
+    sortOrder: SortOrder = 'desc',
 ): Promise<{ maps: any[] }> => {
     const replays = db.collection('replays');
     const trimmedMapName = mapName?.trim();
+    const sortDirection = sortOrder === 'asc' ? 1 : -1;
 
     const replayStatsPipeline: any[] = [
         {
@@ -152,38 +158,11 @@ export const getPaginatedMaps = async (
         },
     ];
 
-    // optimize for case where no mapName filter is applied
-    if (!trimmedMapName) {
-        const pipeline = [
-            ...replayStatsPipeline,
-            { $sort: { lastUpdate: -1 } },
-            { $skip: offset },
-            { $limit: limit },
-            {
-                $lookup: {
-                    from: 'maps',
-                    localField: '_id',
-                    foreignField: '_id',
-                    as: 'map',
-                },
-            },
-            {
-                $replaceRoot: { newRoot: { $mergeObjects: [{ $arrayElemAt: ['$map', 0] }, '$$ROOT'] } },
-            },
-            {
-                $project: {
-                    _id: false,
-                    mapUId: true,
-                    mapName: true,
-                    count: '$count',
-                    lastUpdate: true,
-                },
-            },
-        ];
-
-        const cursor = replays.aggregate(pipeline);
-        const maps = await cursor.toArray();
-        return { maps };
+    let populatedSortStage: any = { $sort: { lastUpdate: sortDirection } };
+    if (sortBy === 'map_name') {
+        populatedSortStage = { $sort: { mapName: sortDirection } };
+    } else if (sortBy === 'replay_count') {
+        populatedSortStage = { $sort: { count: sortDirection } };
     }
 
     const pipeline: any[] = [
@@ -208,12 +187,7 @@ export const getPaginatedMaps = async (
                 lastUpdate: true,
             },
         },
-        {
-            $match: { mapName: { $regex: `.*${trimmedMapName}.*`, $options: 'i' } },
-        },
-        {
-            $sort: { lastUpdate: -1 },
-        },
+        populatedSortStage,
         {
             $skip: offset,
         },
@@ -221,6 +195,12 @@ export const getPaginatedMaps = async (
             $limit: limit,
         },
     ];
+
+    if (trimmedMapName) {
+        pipeline.splice(4, 0, {
+            $match: { mapName: { $regex: `.*${trimmedMapName}.*`, $options: 'i' } },
+        });
+    }
 
     const cursor = replays.aggregate(pipeline);
     const maps = await cursor.toArray();

--- a/server/src/routes/maps.ts
+++ b/server/src/routes/maps.ts
@@ -22,15 +22,30 @@ const router = express.Router();
  * - mapName (optional)
  * - offset (optional, default: 0)
  * - limit (optional, default: 50)
+ * - sortBy (optional: map_name | last_updated | replay_count, default: last_updated)
+ * - sortOrder (optional: asc | desc, default: desc)
  */
 router.get('/', async (req: Request, res: Response, next: Function) => {
     try {
         const offset = parseInt(req.query.offset as string || '0', 10);
         const limit = parseInt(req.query.limit as string || '50', 10);
+        const sortByQuery = req.query.sortBy as string | undefined;
+        const sortOrderQuery = req.query.sortOrder as string | undefined;
+        const sortBy: db.MapSortBy = (sortByQuery === 'map_name'
+            || sortByQuery === 'last_updated'
+            || sortByQuery === 'replay_count')
+            ? sortByQuery
+            : 'last_updated';
+        const sortOrder: db.SortOrder = (sortOrderQuery === 'asc' || sortOrderQuery === 'desc')
+            ? sortOrderQuery
+            : 'desc';
+
         const result = await db.getPaginatedMaps(
             req.query.mapName as string,
             offset,
             limit,
+            sortBy,
+            sortOrder,
         );
         res.send(result);
     } catch (err) {


### PR DESCRIPTION
When implementing pagination, it broke the client side Table sorting on the map list of the homepage
The API /maps GET endpoint now takes a sortBy and a sortOrder argument
The front end table has also been modified to take those API changes into account