### PR TITLE
Optimize maps endpoint

### DIFF
--- a/app/components/landing/MapReplayTableWithSearchbar.tsx
+++ b/app/components/landing/MapReplayTableWithSearchbar.tsx
@@ -64,6 +64,7 @@ const MapReplayTableWithSearchbar = () => {
             key: 'map_name',
             dataIndex: 'mapName',
             sorter: true,
+            sortDirections: ['descend', 'ascend'],
             sortOrder: sortBy === 'map_name' ? currentAntSortOrder : null,
             width: '60%',
             onCell: () => ({
@@ -126,6 +127,7 @@ const MapReplayTableWithSearchbar = () => {
                 );
             },
             sorter: true,
+            sortDirections: ['descend', 'ascend'],
             sortOrder: sortBy === 'last_updated' ? currentAntSortOrder : null,
             width: '15%',
         },
@@ -135,6 +137,7 @@ const MapReplayTableWithSearchbar = () => {
             dataIndex: 'count',
             render: (count) => count.toLocaleString(),
             sorter: true,
+            sortDirections: ['descend', 'ascend'],
             sortOrder: sortBy === 'replay_count' ? currentAntSortOrder : null,
             width: '15%',
         },
@@ -215,15 +218,24 @@ const MapReplayTableWithSearchbar = () => {
                         | 'descend'
                         | undefined;
 
-                    if (!columnSortBy || !columnSortOrder) {
+                    if (!columnSortBy) {
                         setSortBy('last_updated');
                         setSortOrder('desc');
                     } else {
                         const newSortBy = columnSortBy;
-                        const newSortOrder =
-                            columnSortOrder === 'ascend'
-                                ? ('asc' as MapSortOrder)
-                                : ('desc' as MapSortOrder);
+                        let newSortOrder: MapSortOrder;
+                        if (columnSortOrder === 'ascend') {
+                            newSortOrder = 'asc';
+                        } else if (columnSortOrder === 'descend') {
+                            newSortOrder = 'desc';
+                        } else if (
+                            newSortBy === sortBy &&
+                            sortOrder === 'desc'
+                        ) {
+                            newSortOrder = 'asc';
+                        } else {
+                            newSortOrder = 'desc';
+                        }
                         const sortChanged =
                             newSortBy !== sortBy || newSortOrder !== sortOrder;
                         setSortBy(newSortBy);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,14 +1,14 @@
 import { config } from 'dotenv';
 
 import { Request, Response } from 'express';
-import * as express from 'express';
+import express = require('express');
 
 import * as https from 'https';
 import * as fs from 'fs';
-import * as cors from 'cors';
+import cors = require('cors');
 import * as bodyParser from 'body-parser';
-import * as cookieParser from 'cookie-parser';
-import * as compression from 'compression';
+import cookieParser = require('cookie-parser');
+import compression = require('compression');
 
 import * as db from './lib/db';
 import { logError, logInfo, initLogger } from './lib/logger';
@@ -28,7 +28,7 @@ import reqResLoggerMiddleware from './middleware/reqResLogger';
 config();
 
 // initialize the logger with the provided level first
-initLogger(process.env.LOG_LEVEL);
+initLogger(process.env.LOG_LEVEL || '');
 
 const app = express();
 app.use(
@@ -67,17 +67,22 @@ app.use(cookieParser());
 // Response compression (using fastest compression preset)
 app.use(compression({ level: 1 }));
 
-app.listen(defaultPort, () => {
-    logInfo(`App listening on port ${defaultPort}`);
-});
-
-// initialize DB connection
-db.initDB();
+const startApp = async () => {
+    try {
+        await db.initDB();
+        app.listen(defaultPort, () => {
+            logInfo(`App listening on port ${defaultPort}`);
+        });
+    } catch (error) {
+        logError(error instanceof Error ? error.stack || error.message : String(error));
+        process.exit(1);
+    }
+};
 
 // global error handler (requires 'next' even if it's not used)
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 app.use((err: Error, req: Request, res: Response, next: Function) => {
-    logError(err.stack);
+    logError(err.stack || err.message);
     res.status(500).send('Internal server error');
 });
 
@@ -94,3 +99,5 @@ app.use('/maps', mapRouter);
 app.use('/users', userRouter);
 app.use('/me', meRouter);
 app.use('/replays', replayRouter);
+
+startApp();

--- a/server/src/lib/db.ts
+++ b/server/src/lib/db.ts
@@ -3,130 +3,200 @@ import { config } from 'dotenv';
 import { v4 as uuid } from 'uuid';
 import { Request } from 'express';
 import { playerLoginFromWebId, UserInfoResponse } from './authorize';
-import { logError, logInfo } from './logger';
+import { logInfo } from './logger';
 import { DiscordWebhook } from './discordWebhooks/discordWebhook';
 
 config();
 
 const DB_NAME = 'dojo';
 
-let db: Db = null;
+let db: Db | null = null;
+
+const getDb = (): Db => {
+    if (!db) {
+        throw new Error('Database connection has not been initialized');
+    }
+    return db;
+};
 
 export type Rejector = (_1: Error) => void;
 
 export type MapSortBy = 'map_name' | 'last_updated' | 'replay_count';
 export type SortOrder = 'desc' | 'asc';
 
-export const initDB = () => {
-    const mongoClient = new MongoClient(process.env.MONGO_URL, {
+export const initDB = async () => {
+    const mongoUrl = process.env.MONGO_URL;
+    if (!mongoUrl) {
+        throw new Error('MONGO_URL is not configured');
+    }
+
+    const mongoClient = new MongoClient(mongoUrl, {
         useUnifiedTopology: true,
     } as any);
 
-    mongoClient.connect((err: Error) => {
-        if (err) {
-            logError('initDB: Could not connect to DB, shutting down');
-            process.exit();
-        }
-        logInfo('initDB: Connected successfully to DB');
-        db = mongoClient.db(DB_NAME);
-    });
+    await mongoClient.connect();
+    logInfo('initDB: Connected successfully to DB');
+    db = mongoClient.db(DB_NAME);
+    await syncMapReplayStats();
 };
 
-export const createUser = (
+export const syncMapReplayStats = async (): Promise<void> => {
+    const database = getDb();
+    const maps = database.collection('maps');
+    const replays = database.collection('replays');
+
+    logInfo('syncMapReplayStats: Rebuilding cached map replay stats');
+
+    const replayStats = await replays.aggregate([
+        {
+            $match: {
+                private: { $ne: true },
+            },
+        },
+        {
+            $group: {
+                _id: '$mapRef',
+                replayCount: { $sum: 1 },
+                lastReplayAt: { $max: '$date' },
+            },
+        },
+    ]).toArray();
+
+    await maps.updateMany({}, {
+        $set: {
+            replayCount: 0,
+            lastReplayAt: null,
+        },
+    });
+
+    if (replayStats.length) {
+        await maps.bulkWrite(replayStats.map((stat) => ({
+            updateOne: {
+                filter: { _id: stat._id },
+                update: {
+                    $set: {
+                        replayCount: stat.replayCount,
+                        lastReplayAt: stat.lastReplayAt,
+                    },
+                },
+            },
+        })));
+    }
+
+    logInfo(`syncMapReplayStats: Updated ${replayStats.length} maps`);
+};
+
+export const createUser = async (
     req: Request,
     webId: any,
     login: any,
     name: any,
     clientCode: any,
-): Promise<{ userID: string }> => new Promise(
-    (resolve: (updateInfo: { userID: string }) => void, reject: Rejector) => {
-        const users = db.collection('users');
-        users
-            .find({
+): Promise<{ userID: string }> => {
+    try {
+        const users = getDb().collection('users');
+        const docs = await users.find({ webId }).toArray();
+        if (!docs.length) {
+            const insertedUserData = await users.insertOne({
                 webId,
-            })
-            .toArray(async (err: Error, docs: any) => {
-                if (err) {
-                    req.log.error(`createUser: Error finding user with webId ${webId}`);
-                    reject(err);
-                } else if (!docs.length) {
-                    const insertedUserData = await users.insertOne({
-                        webId,
-                        playerLogin: login,
-                        playerName: name,
-                        privateReplays: false,
-                        clientCode: clientCode || null,
-                        createdAt: Date.now(),
-                    });
-
-                    req.log.debug(
-                        `createUser: Created new user "${name}", doc ID: ${insertedUserData.insertedId.toString()}`,
-                    );
-
-                    // Send discord alert for new user
-                    DiscordWebhook.sendNewUserAlert(req, name, users);
-
-                    resolve({ userID: insertedUserData.insertedId?.toString() });
-                } else {
-                    req.log.debug(`createUser: User "${name}" already exists, doc ID: ${docs[0]._id.toString()}`);
-                    const updatedUser = {
-                        $set: {
-                            playerLogin: login,
-                            playerName: name,
-                            clientCode: clientCode || null,
-                        },
-                    };
-                    await users.updateOne(
-                        {
-                            webId,
-                        },
-                        updatedUser,
-                    );
-                    req.log.debug(`createUser: Updated user "${name}"`);
-                    // inserts are explicit, this will always be an existing doc (so passing the known ID is fine)
-                    resolve({ userID: docs[0]._id.toString() });
-                }
+                playerLogin: login,
+                playerName: name,
+                privateReplays: false,
+                clientCode: clientCode || null,
+                createdAt: Date.now(),
             });
-    },
-);
 
-export const getMapsStats = async (): Promise<any> => {
-    const replays = db.collection('replays');
+            req.log.debug(
+                `createUser: Created new user "${name}", doc ID: ${insertedUserData.insertedId.toString()}`,
+            );
 
-    const queryPipeline = [
+            DiscordWebhook.sendNewUserAlert(req, name, users);
+            return { userID: insertedUserData.insertedId.toString() };
+        }
+
+        req.log.debug(`createUser: User "${name}" already exists, doc ID: ${docs[0]._id.toString()}`);
+        await users.updateOne(
+            { webId },
+            {
+                $set: {
+                    playerLogin: login,
+                    playerName: name,
+                    clientCode: clientCode || null,
+                },
+            },
+        );
+        req.log.debug(`createUser: Updated user "${name}"`);
+        return { userID: docs[0]._id.toString() };
+    } catch (error) {
+        req.log.error(`createUser: Error finding user with webId ${webId}`);
+        throw error instanceof Error ? error : new Error(String(error));
+    }
+};
+
+export const incrementMapReplayStats = async (mapRef: ObjectId, replayDate: number): Promise<void> => {
+    const maps = getDb().collection('maps');
+    await maps.updateOne(
+        { _id: mapRef },
+        {
+            $inc: { replayCount: 1 },
+            $max: { lastReplayAt: replayDate },
+        },
+    );
+};
+
+export const refreshMapReplayStats = async (mapRef: ObjectId): Promise<void> => {
+    const database = getDb();
+    const maps = database.collection('maps');
+    const replays = database.collection('replays');
+
+    const [stats] = await replays.aggregate([
+        {
+            $match: {
+                mapRef,
+                private: { $ne: true },
+            },
+        },
         {
             $group: {
                 _id: '$mapRef',
-                count: {
-                    $sum: 1,
-                },
-                lastUpdate: { $max: '$date' }, // pass the highest date (i.e. latest replay's timestamp)
+                replayCount: { $sum: 1 },
+                lastReplayAt: { $max: '$date' },
             },
         },
-        // populate map references to count occurrences
+    ]).toArray();
+
+    await maps.updateOne(
+        { _id: mapRef },
         {
-            $lookup: {
-                from: 'maps',
-                localField: '_id',
-                foreignField: '_id',
-                as: 'map',
+            $set: {
+                replayCount: stats?.replayCount || 0,
+                lastReplayAt: stats?.lastReplayAt || null,
             },
         },
+    );
+};
+
+export const getMapsStats = async (): Promise<any> => {
+    const maps = getDb().collection('maps');
+
+    const queryPipeline = [
         {
-            $replaceRoot: { newRoot: { $mergeObjects: [{ $arrayElemAt: ['$map', 0] }, '$$ROOT'] } },
+            $match: {
+                replayCount: { $gt: 0 },
+            },
         },
         {
             $project: {
                 _id: false,
                 mapUId: true,
                 mapName: true,
-                count: '$count',
-                lastUpdate: true,
+                count: '$replayCount',
+                lastUpdate: '$lastReplayAt',
             },
         },
     ];
 
-    const cursor = replays.aggregate(queryPipeline);
+    const cursor = maps.aggregate(queryPipeline);
     const data = await cursor.toArray();
 
     return data;
@@ -139,24 +209,9 @@ export const getPaginatedMaps = async (
     sortBy: MapSortBy = 'last_updated',
     sortOrder: SortOrder = 'desc',
 ): Promise<{ maps: any[] }> => {
-    const replays = db.collection('replays');
+    const maps = getDb().collection('maps');
     const trimmedMapName = mapName?.trim();
     const sortDirection = sortOrder === 'asc' ? 1 : -1;
-
-    const replayStatsPipeline: any[] = [
-        {
-            $match: {
-                private: { $ne: true },
-            },
-        },
-        {
-            $group: {
-                _id: '$mapRef',
-                count: { $sum: 1 },
-                lastUpdate: { $max: '$date' },
-            },
-        },
-    ];
 
     let populatedSortStage: any = { $sort: { lastUpdate: sortDirection } };
     if (sortBy === 'map_name') {
@@ -165,26 +220,24 @@ export const getPaginatedMaps = async (
         populatedSortStage = { $sort: { count: sortDirection } };
     }
 
+    const matchStage: any = {
+        replayCount: { $gt: 0 },
+    };
+    if (trimmedMapName) {
+        matchStage.mapName = { $regex: `.*${trimmedMapName}.*`, $options: 'i' };
+    }
+
     const pipeline: any[] = [
-        ...replayStatsPipeline,
         {
-            $lookup: {
-                from: 'maps',
-                localField: '_id',
-                foreignField: '_id',
-                as: 'map',
-            },
-        },
-        {
-            $replaceRoot: { newRoot: { $mergeObjects: [{ $arrayElemAt: ['$map', 0] }, '$$ROOT'] } },
+            $match: matchStage,
         },
         {
             $project: {
                 _id: false,
                 mapUId: true,
                 mapName: true,
-                count: '$count',
-                lastUpdate: true,
+                count: '$replayCount',
+                lastUpdate: '$lastReplayAt',
             },
         },
         populatedSortStage,
@@ -196,84 +249,69 @@ export const getPaginatedMaps = async (
         },
     ];
 
-    if (trimmedMapName) {
-        pipeline.splice(4, 0, {
-            $match: { mapName: { $regex: `.*${trimmedMapName}.*`, $options: 'i' } },
-        });
-    }
-
-    const cursor = replays.aggregate(pipeline);
-    const maps = await cursor.toArray();
-    return { maps };
+    const cursor = maps.aggregate(pipeline);
+    const paginatedMaps = await cursor.toArray();
+    return { maps: paginatedMaps };
 };
 
 export const getTotalMapCount = async (mapName?: string): Promise<number> => {
-    const maps = db.collection('maps');
+    const maps = getDb().collection('maps');
 
-    let filter: any = {};
+    const filter: any = {
+        replayCount: { $gt: 0 },
+    };
     if (mapName && mapName !== '') {
-        filter = { mapName: { $regex: `.*${mapName}.*`, $options: 'i' } };
+        filter.mapName = { $regex: `.*${mapName}.*`, $options: 'i' };
     }
 
-    const pipeline = [
+    const [result] = await maps.aggregate([
         { $match: filter },
-        { $group: { _id: '$mapUId' } },
         { $count: 'total' },
-    ];
+    ]).toArray();
 
-    const cursor = maps.aggregate(pipeline);
-    const [result] = await cursor.toArray();
     return result?.total || 0;
 };
 
 export const getTotalReplayCount = async (): Promise<number> => {
-    const replays = db.collection('replays');
+    const replays = getDb().collection('replays');
     const count = await replays.countDocuments({ private: { $ne: true } });
     return count;
 };
 
-export const getMapByUId = (mapUId?: string): Promise<any> => new Promise((resolve: Function, reject: Rejector) => {
-    const maps = db.collection('maps');
-    maps.findOne({ mapUId }, (err: Error, map: any) => {
-        if (err) {
-            return reject(err);
-        }
-        return resolve(map);
-    });
-});
+export const getMapByUId = async (mapUId?: string): Promise<any> => {
+    const maps = getDb().collection('maps');
+    return maps.findOne({ mapUId });
+};
 
 export const saveMap = (mapData?: any): Promise<any> => new Promise((resolve: Function, reject: Rejector) => {
-    const maps = db.collection('maps');
-    maps.insertOne(mapData)
+    const maps = getDb().collection('maps');
+    maps.insertOne({
+        replayCount: 0,
+        lastReplayAt: null,
+        ...mapData,
+    })
         .then((operation: any) => resolve({ _id: operation.insertedId }))
         .catch((error: Error) => reject(error));
 });
 
 // Gets a user by the _id field in the db
 export const getUserById = async (id: string) => {
-    const users = db.collection('users');
+    const users = getDb().collection('users');
     return users.findOne({
         _id: new ObjectId(id),
     });
 };
 
-export const getUserByWebId = (
-    webId?: string,
-): Promise<any> => new Promise((resolve: Function, reject: Rejector) => {
-    const users = db.collection('users');
-    users.findOne({ webId }, (err: Error, user: any) => {
-        if (err) {
-            return reject(err);
-        }
-        return resolve(user);
-    });
-});
+export const getUserByWebId = async (webId?: string): Promise<any> => {
+    const users = getDb().collection('users');
+    return users.findOne({ webId });
+};
 
 export const getReplaysByUserRef = async (
     userRef: string,
     showPrivate: boolean = false,
 ): Promise<any> => {
-    const replays = db.collection('replays');
+    const replays = getDb().collection('replays');
 
     let matchCondition: any = { userRef: new ObjectId(userRef) };
 
@@ -307,7 +345,7 @@ export const setUserPrivateReplays = async (
     webId: string,
     privateReplays: boolean,
 ) => {
-    const users = db.collection('users');
+    const users = getDb().collection('users');
     return users.updateOne(
         { webId },
         {
@@ -327,7 +365,7 @@ export const getReplays = async (
     maxResults: string = '1000',
     currentUserRef?: string,
 ): Promise<any> => {
-    const replays = db.collection('replays');
+    const replays = getDb().collection('replays');
 
     const pipeline = [];
 
@@ -390,7 +428,7 @@ export const getReplays = async (
         if (property) {
             pipeline.push({
                 $match: {
-                    [propertyName]: {
+                    [propertyName as string]: {
                         $regex: `.*${property}.*`,
                         $options: 'i',
                     },
@@ -444,7 +482,7 @@ export const getReplayById = async (
     replayId?: string,
     populate?: boolean,
 ): Promise<any> => {
-    const replays = db.collection('replays');
+    const replays = getDb().collection('replays');
 
     let pipeline = [
         {
@@ -494,28 +532,21 @@ export const getReplayById = async (
 };
 
 export const deleteReplayById = async (replayId: any) => {
-    const replays = db.collection('replays');
+    const replays = getDb().collection('replays');
     await replays.deleteOne({
         _id: new ObjectId(replayId),
     });
 };
 
-export const getReplayByFilePath = (
-    filePath?: string,
-): Promise<any> => new Promise((resolve: Function, reject: Rejector) => {
-    const replays = db.collection('replays');
-    replays.findOne({ filePath }, (err: Error, replay: any) => {
-        if (err) {
-            return reject(err);
-        }
-        return resolve(replay);
-    });
-});
+export const getReplayByFilePath = async (filePath?: string): Promise<any> => {
+    const replays = getDb().collection('replays');
+    return replays.findOne({ filePath });
+};
 
 export const saveReplayMetadata = (
     metadata: any,
 ): Promise<{ _id: string }> => new Promise((resolve: Function, reject: Rejector) => {
-    const replays = db.collection('replays');
+    const replays = getDb().collection('replays');
     replays.insertOne(metadata)
         .then(({ insertedId }: { insertedId: ObjectId }) => resolve({ _id: insertedId }))
         .catch((error: Error) => reject(error));
@@ -547,7 +578,7 @@ export const createSession = async (req: Request, userInfo: UserInfoResponse, cl
     }
 
     // Create session
-    const sessions = db.collection('sessions');
+    const sessions = getDb().collection('sessions');
     const sessionId = uuid();
     await sessions.insertOne({
         sessionId,
@@ -562,22 +593,22 @@ export const updateSession = async (session: any) => {
     if (!session._id) {
         throw new Error('Session without _id cannot be updated');
     }
-    const sessions = db.collection('sessions');
+    const sessions = getDb().collection('sessions');
     return sessions.replaceOne({ _id: session._id }, session);
 };
 
 export const findSessionBySecret = async (sessionId: string) => {
-    const sessions = db.collection('sessions');
+    const sessions = getDb().collection('sessions');
     return sessions.findOne({ sessionId });
 };
 
 export const findSessionByClientCode = async (clientCode: string) => {
-    const sessions = db.collection('sessions');
+    const sessions = getDb().collection('sessions');
     return sessions.findOne({ clientCode });
 };
 
 export const deleteSession = async (sessionId: string) => {
-    const sessions = db.collection('sessions');
+    const sessions = getDb().collection('sessions');
     await sessions.deleteOne({
         sessionId,
     });
@@ -589,7 +620,7 @@ export const deleteSession = async (sessionId: string) => {
  */
 export const getUserBySessionId = async (sessionId: string) => {
     // Find session
-    const sessions = db.collection('sessions');
+    const sessions = getDb().collection('sessions');
     const session = await sessions.findOne({
         sessionId,
     });
@@ -600,7 +631,7 @@ export const getUserBySessionId = async (sessionId: string) => {
     }
 
     // Find user
-    const users = db.collection('users');
+    const users = getDb().collection('users');
     const user = await users.findOne({
         _id: session.userRef,
     });

--- a/server/src/lib/db.ts
+++ b/server/src/lib/db.ts
@@ -24,22 +24,6 @@ export type Rejector = (_1: Error) => void;
 export type MapSortBy = 'map_name' | 'last_updated' | 'replay_count';
 export type SortOrder = 'desc' | 'asc';
 
-export const initDB = async () => {
-    const mongoUrl = process.env.MONGO_URL;
-    if (!mongoUrl) {
-        throw new Error('MONGO_URL is not configured');
-    }
-
-    const mongoClient = new MongoClient(mongoUrl, {
-        useUnifiedTopology: true,
-    } as any);
-
-    await mongoClient.connect();
-    logInfo('initDB: Connected successfully to DB');
-    db = mongoClient.db(DB_NAME);
-    await syncMapReplayStats();
-};
-
 export const syncMapReplayStats = async (): Promise<void> => {
     const database = getDb();
     const maps = database.collection('maps');
@@ -84,6 +68,22 @@ export const syncMapReplayStats = async (): Promise<void> => {
     }
 
     logInfo(`syncMapReplayStats: Updated ${replayStats.length} maps`);
+};
+
+export const initDB = async () => {
+    const mongoUrl = process.env.MONGO_URL;
+    if (!mongoUrl) {
+        throw new Error('MONGO_URL is not configured');
+    }
+
+    const mongoClient = new MongoClient(mongoUrl, {
+        useUnifiedTopology: true,
+    } as any);
+
+    await mongoClient.connect();
+    logInfo('initDB: Connected successfully to DB');
+    db = mongoClient.db(DB_NAME);
+    await syncMapReplayStats();
 };
 
 export const createUser = async (

--- a/server/src/routes/replays.ts
+++ b/server/src/routes/replays.ts
@@ -201,6 +201,14 @@ router.post('/', (req: Request, res: Response, next: Function): any => {
             req.log.debug('replaysRouter: Saving replay metadata');
             await db.saveReplayMetadata(metadata);
 
+            if (!metadata.private) {
+                try {
+                    await db.incrementMapReplayStats(map._id, metadata.date);
+                } catch (error) {
+                    req.log.warn(`replaysRouter: Failed to update cached map stats after upload: ${error}`);
+                }
+            }
+
             return res.send();
         } catch (err) {
             return next(err);
@@ -239,6 +247,14 @@ router.delete('/:replayId', async (req, res) => {
     try {
         req.log.debug('replaysRouter: Deleted replay metadata, now deleting replay file');
         await artefacts.deleteReplay(replay);
+
+        if (!replay.private) {
+            try {
+                await db.refreshMapReplayStats(replay.mapRef);
+            } catch (error) {
+                req.log.warn(`replaysRouter: Failed to refresh cached map stats after delete: ${error}`);
+            }
+        }
     } catch (err) {
         req.log.warn('replaysRouter: Failed to delete replay file, restoring metadata in database');
         // If deletion failed, add the replay back into the DB


### PR DESCRIPTION
For the GET endpoint for /maps (the list of the maps displayed on the homepage), we would count every replay (from 2+ millions replays) for every map (94k+ maps) on each request.
Which is really slow (about 12 seconds per request)

Now, we store the last updated replay date + replay count for each map in it's own mongo document
We no longer need to query the replays collection because the information we need is already available in the maps collection.

This optimization results in a 26x speed up for the /maps request, from 12 seconds to 450 ms

Additionnaly, when the API starts up, it will update the maps collection from the replays collection (takes around 12 seconds) but only once.

All subsequent replay upload / deletion will only update it's corresponding map stats